### PR TITLE
More efficient cube parsing

### DIFF
--- a/src/xyzrender/cube.py
+++ b/src/xyzrender/cube.py
@@ -44,55 +44,51 @@ def parse_cube(path: str | Path) -> CubeData:
     """
     path = Path(path)
     with open(path) as f:
-        lines = f.readlines()
+        # Lines 1-2: title and comment
+        title = f.readline().strip()
+        comment = f.readline().strip()
+        logger.debug("Cube file: %s / %s", title, comment)
 
-    title = lines[0].strip()
-    comment = lines[1].strip()
-    logger.debug("Cube file: %s / %s", title, comment)
+        # Line 3: natoms, origin
+        parts = f.readline().split()
+        natoms_raw = int(parts[0])
+        is_mo = natoms_raw < 0
+        natoms = abs(natoms_raw)
+        origin = np.array([float(parts[1]), float(parts[2]), float(parts[3])])
 
-    # Line 3: natoms, origin
-    parts = lines[2].split()
-    natoms_raw = int(parts[0])
-    is_mo = natoms_raw < 0
-    natoms = abs(natoms_raw)
-    origin = np.array([float(parts[1]), float(parts[2]), float(parts[3])])
+        # Lines 4-6: grid dimensions and step vectors
+        grid_ns = []
+        step_vecs = []
+        for _ in range(3):
+            parts = f.readline().split()
+            grid_ns.append(int(parts[0]))
+            step_vecs.append([float(parts[1]), float(parts[2]), float(parts[3])])
+        grid_shape = tuple(grid_ns)
+        steps = np.array(step_vecs)
 
-    # Lines 4-6: grid dimensions and step vectors
-    grid_ns = []
-    step_vecs = []
-    for i in range(3):
-        parts = lines[3 + i].split()
-        grid_ns.append(int(parts[0]))
-        step_vecs.append([float(parts[1]), float(parts[2]), float(parts[3])])
-    grid_shape = tuple(grid_ns)
-    steps = np.array(step_vecs)
+        # Atom lines
+        atoms = []
+        for _ in range(natoms):
+            parts = f.readline().split()
+            z = int(parts[0])
+            sym = DATA.n2s.get(z, "X")
+            coords = np.array([float(parts[2]), float(parts[3]), float(parts[4])])
+            atoms.append((sym, tuple(coords * BOHR_TO_ANG)))
 
-    # Atom lines
-    atoms = []
-    for i in range(natoms):
-        parts = lines[6 + i].split()
-        z = int(parts[0])
-        sym = DATA.n2s.get(z, "X")
-        x, y, zc = float(parts[2]), float(parts[3]), float(parts[4])
-        atoms.append((sym, (x * BOHR_TO_ANG, y * BOHR_TO_ANG, zc * BOHR_TO_ANG)))
+        # MO index line (only for MO cube files)
+        mo_index = None
+        data_start = 6 + natoms
+        if is_mo:
+            mo_parts = f.readline().split()
+            if len(mo_parts) >= 2:
+                mo_index = int(mo_parts[1])
+            data_start += 1
 
-    # MO index line (only for MO cube files)
-    mo_index = None
-    data_start = 6 + natoms
-    if is_mo:
-        mo_parts = lines[data_start].split()
-        if len(mo_parts) >= 2:
-            mo_index = int(mo_parts[1])
-        data_start += 1
+        # Volumetric data — parse all remaining floats at once
+        grid_data = np.fromstring(f.read(), dtype=np.float64, sep=" ")
 
-    # Volumetric data — parse all remaining floats in one numpy call
     expected = grid_shape[0] * grid_shape[1] * grid_shape[2]
-    raw = " ".join(lines[data_start:])
-    grid_data = np.fromstring(raw, dtype=np.float64, sep=" ")
-
-    if grid_data.size != expected:
-        raise ValueError(f"Cube data count mismatch: got {grid_data.size}, expected {expected}")
-
+    assert grid_data.size == expected, f"Cube data count mismatch: got {grid_data.size}, expected {expected}"
     grid_data = grid_data.reshape(grid_shape)
 
     logger.debug(


### PR DESCRIPTION
Removes the call to `.join()` on the cube data, and just reads the data straight from the open file. This is ~50% faster.

Benchmarking code 

```python
import numpy as np
from xyzrender.cube import parse_cube
from pathlib import Path
import time

cubes = list(Path("examples/structures").glob("*.cube"))
cubedata = []
for cube in cubes:
    start = time.time()
    cubedata.append(parse_cube(cube))
    end = time.time()
    print(f"Parsed {cube} in {end - start:.4f} seconds")
```


```
# Old way
Parsed examples/structures/base-pair-dens.cube in 0.1696 seconds
Parsed examples/structures/base-pair-grad.cube in 0.1949 seconds
Parsed examples/structures/caffeine_dens.cube in 0.2795 seconds
Parsed examples/structures/caffeine_esp.cube in 0.2925 seconds
Parsed examples/structures/caffeine_homo.cube in 0.2927 seconds
Parsed examples/structures/caffeine_lumo.cube in 0.2890 seconds
Parsed examples/structures/phenol_di-dens.cube in 0.1385 seconds
Parsed examples/structures/phenol_di-grad.cube in 0.1224 seconds

# New way
Parsed examples/structures/base-pair-dens.cube in 0.0749 seconds
Parsed examples/structures/base-pair-grad.cube in 0.0895 seconds
Parsed examples/structures/caffeine_dens.cube in 0.1541 seconds
Parsed examples/structures/caffeine_esp.cube in 0.1308 seconds
Parsed examples/structures/caffeine_homo.cube in 0.1340 seconds
Parsed examples/structures/caffeine_lumo.cube in 0.1229 seconds
Parsed examples/structures/phenol_di-dens.cube in 0.0650 seconds
Parsed examples/structures/phenol_di-grad.cube in 0.0599 seconds
```

