### PR TITLE
Fix DoF PDF export via filter-preserving raster fallback

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -4,12 +4,16 @@
 
 ```bash
 pip install xyzrender
+# latest development version (recommended for newest flags/fixes):
+pip install --upgrade git+https://github.com/aligfellow/xyzrender.git
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):
 
 ```bash
 uv tool install xyzrender
+# latest development version:
+uv tool install git+https://github.com/aligfellow/xyzrender.git
 ```
 
 To test without installing:

--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -1956,11 +1956,19 @@ def _write_output(svg: str, output: Path, cfg: RenderConfig) -> None:
 
         svg_to_png(svg, str(output), size=cfg.canvas_size, dpi=getattr(cfg, "dpi", 300))
     elif ext == ".pdf":
-        if cfg.dof:
-            logger.warning("PDF output uses cairosvg which does not support SVG filters — --dof blur will not appear")
         from xyzrender.export import svg_to_pdf
 
-        svg_to_pdf(svg, str(output))
+        if cfg.dof:
+            logger.warning("PDF + --dof: rasterizing SVG filters via PNG fallback (non-vector PDF output)")
+            svg_to_pdf(
+                svg,
+                str(output),
+                preserve_filters=True,
+                size=cfg.canvas_size,
+                dpi=getattr(cfg, "dpi", 300),
+            )
+        else:
+            svg_to_pdf(svg, str(output))
     else:
         msg = f"Unsupported output format: {ext!r} (use .svg, .png, or .pdf)"
         raise ValueError(msg)

--- a/src/xyzrender/cli.py
+++ b/src/xyzrender/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -60,9 +61,15 @@ def _parse_atom_spec(s: str) -> list[int]:
 
 def main() -> None:
     """Entry point for the CLI."""
+    try:
+        _version = version("xyzrender")
+    except PackageNotFoundError:
+        _version = "dev"
+
     p = argparse.ArgumentParser(
         prog="xyzrender", description="Publication-quality molecular graphics from the command line."
     )
+    p.add_argument("--version", action="version", version=f"%(prog)s {_version}")
 
     # --- Input / Output ---
     io_g = p.add_argument_group("input/output")

--- a/src/xyzrender/export.py
+++ b/src/xyzrender/export.py
@@ -2,11 +2,13 @@
 
 PNG rendering prefers **resvg-py** — it supports SVG filter primitives
 (``feGaussianBlur``, ``feTurbulence``, etc.) that cairosvg silently ignores.
-PDF rendering uses cairosvg (resvg-py has no PDF support).
+PDF rendering defaults to cairosvg (vector output). For filtered SVGs (for
+example ``--dof``), a PNG->PDF fallback is available to preserve filters.
 """
 
 from __future__ import annotations
 
+from io import BytesIO
 from functools import lru_cache
 
 _SVG_BASE_DPI = 96  # CSS/SVG spec: 1px = 1/96 inch
@@ -55,8 +57,49 @@ def svg_to_png(svg: str, output: str, *, size: int = 800, dpi: int = 300) -> Non
         f.write(data)
 
 
-def svg_to_pdf(svg: str, output: str) -> None:
-    """Convert SVG string to PDF file via cairosvg."""
-    import cairosvg
+def svg_to_pdf(
+    svg: str, output: str, *, preserve_filters: bool = False, size: int = 800, dpi: int = 300
+) -> None:
+    """Convert SVG string to a PDF file.
 
-    cairosvg.svg2pdf(bytestring=svg.encode(), write_to=output)
+    Parameters
+    ----------
+    svg:
+        SVG source.
+    output:
+        Output PDF path.
+    preserve_filters:
+        If ``True``, rasterize SVG to PNG first (via :func:`svg_to_png`) and
+        then embed into PDF so SVG filter effects (e.g. Gaussian blur) are kept.
+        This produces a raster PDF page instead of vector graphics.
+    size:
+        Canvas size in pixels for the raster fallback.
+    dpi:
+        Rasterization resolution for the fallback path.
+    """
+    if not preserve_filters:
+        import cairosvg
+
+        cairosvg.svg2pdf(bytestring=svg.encode(), write_to=output)
+        return
+
+    # Preserve SVG filters by rasterizing first, then writing a single-page PDF.
+    if _has_resvg():
+        from resvg_py import svg_to_bytes
+
+        zoom = max(1, round(dpi / _SVG_BASE_DPI))
+        png_data = svg_to_bytes(svg_string=svg, zoom=zoom)
+    else:
+        import cairosvg
+
+        png_data = cairosvg.svg2png(bytestring=svg.encode(), output_width=size, output_height=size, dpi=dpi)
+    from PIL import Image
+
+    with Image.open(BytesIO(png_data)) as im:
+        if "A" in im.getbands():
+            bg = Image.new("RGB", im.size, "white")
+            bg.paste(im, mask=im.getchannel("A"))
+            rgb = bg
+        else:
+            rgb = im.convert("RGB")
+        rgb.save(output, "PDF", resolution=float(dpi))

--- a/src/xyzrender/export.py
+++ b/src/xyzrender/export.py
@@ -8,8 +8,8 @@ example ``--dof``), a PNG->PDF fallback is available to preserve filters.
 
 from __future__ import annotations
 
-from io import BytesIO
 from functools import lru_cache
+from io import BytesIO
 
 _SVG_BASE_DPI = 96  # CSS/SVG spec: 1px = 1/96 inch
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -9,7 +9,11 @@ SIMPLE_SVG = (
 
 @pytest.fixture
 def cairosvg():
-    return pytest.importorskip("cairosvg", reason="cairosvg required")
+    try:
+        import cairosvg as _cairosvg
+    except (ImportError, OSError) as exc:
+        pytest.skip(f"cairosvg/libcairo unavailable: {exc}")
+    return _cairosvg
 
 
 def test_svg_to_png_writes_file(cairosvg, tmp_path):
@@ -28,6 +32,25 @@ def test_svg_to_pdf_writes_file(cairosvg, tmp_path):
 
     out = tmp_path / "out.pdf"
     svg_to_pdf(SIMPLE_SVG, str(out))
+    assert out.exists()
+    assert out.stat().st_size > 0
+    assert out.read_bytes()[:4] == b"%PDF"
+
+
+def test_svg_to_pdf_preserve_filters_writes_file(cairosvg, tmp_path):
+    pytest.importorskip("PIL", reason="Pillow required for raster PDF fallback")
+    from xyzrender.export import svg_to_pdf
+
+    svg = """
+    <svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+      <defs>
+        <filter id="blur"><feGaussianBlur stdDeviation="4"/></filter>
+      </defs>
+      <circle cx="60" cy="60" r="35" fill="red" filter="url(#blur)"/>
+    </svg>
+    """
+    out = tmp_path / "out_blur.pdf"
+    svg_to_pdf(svg, str(out), preserve_filters=True)
     assert out.exists()
     assert out.stat().st_size > 0
     assert out.read_bytes()[:4] == b"%PDF"


### PR DESCRIPTION
This fixes a DoF PDF bug.

Bug:
- `xyzrender ... --dof -o out.pdf` relied on cairosvg PDF conversion, which drops SVG blur filters (and can fail when cairo libs are missing).

Potential Fix:
- when `--dof` + `.pdf` is used, can alternatively render through a raster fallback and embed that in the PDF so the blur is preserved.