### PR TITLE
Fix bond colour double-darkening in btube/pmol

### DIFF
--- a/src/xyzrender/renderer.py
+++ b/src/xyzrender/renderer.py
@@ -405,19 +405,7 @@ def render_svg(graph, config: RenderConfig | None = None, *, _log: bool = True, 
                 continue
             modal = Counter(graph.nodes[m]["symbol"] for m in members).most_common(1)[0][0]
             _endpoint_color[ai] = get_color(DATA.s2n.get(modal, 0), cfg.color_overrides)
-    # Match the darker side of the solid-bond cylinder gradient.
-    if cfg.bond_gradient:
-        _bond_endpoint_hex = [
-            c.darken(
-                strength=cfg.bond_gradient_strength,
-                hue_shift_factor=cfg.hue_shift_factor,
-                light_shift_factor=cfg.light_shift_factor,
-                saturation_shift_factor=cfg.saturation_shift_factor,
-            ).hex
-            for c in _endpoint_color
-        ]
-    else:
-        _bond_endpoint_hex = [c.hex for c in _endpoint_color]
+    _bond_endpoint_hex = [c.hex for c in _endpoint_color]
 
     # Bond lookup: per-edge attrs needed by the render loop.
     bonds: dict[tuple[int, int], _BondAttrs] = {}


### PR DESCRIPTION
Noticed that bonds in `btube` and `pmol` renders were coming out visibly darker than the atom spheres at their junctions. After digging in, the culprit was a double-darkening bug.

When `bond_color_by_element` and `bond_gradient` are both on, `_bond_endpoint_hex` was pre-darkening atom colours with `.darken()` before passing them into the render loop. The problem is that `_shaded_stroke` already calls `get_gradient_colors` on whatever colour it receives — which darkens it again. So the cylinder gradient was being built on top of an already-darkened base, pushing bonds noticeably below the atom colours in brightness.

The fix is straightforward: drop the pre-darkening pass on `_bond_endpoint_hex` entirely. `_shaded_stroke` handles all the gradient work from the atom's true base colour, so bond and atom colours now stay consistent at the junction.