### PR TITLE
Honor manual TS bonds in vibration GIFs

### DIFF
--- a/docs/source/examples/animations.md
+++ b/docs/source/examples/animations.md
@@ -65,6 +65,12 @@ xyzrender mn-h2.log --gif-ts -go mn-h2.gif
 xyzrender bimp.out --gif-rot --gif-ts --vdw 84-169 -go bimp.gif
 ```
 
+Use `--ts-bond` to replace graphRC's detected TS bonds with a manual selection:
+
+```bash
+xyzrender mn-h2.log --gif-ts --ts-bond "1-2" -go mn-h2.gif
+```
+
 ## Trajectory
 
 ```{image} ../../../examples/images/bimp_trj.gif

--- a/docs/source/examples/animations.md
+++ b/docs/source/examples/animations.md
@@ -65,7 +65,7 @@ xyzrender mn-h2.log --gif-ts -go mn-h2.gif
 xyzrender bimp.out --gif-rot --gif-ts --vdw 84-169 -go bimp.gif
 ```
 
-Use `--ts-bond` to replace graphRC's detected TS bonds with a manual selection:
+Use `--ts-bond` to skip automatic TS identification and provide a manual selection:
 
 ```bash
 xyzrender mn-h2.log --gif-ts --ts-bond "1-2" -go mn-h2.gif

--- a/docs/source/examples/ts_nci.md
+++ b/docs/source/examples/ts_nci.md
@@ -4,7 +4,7 @@ xyzrender uses [xyzgraph](https://github.com/aligfellow/xyzgraph) for molecular 
 
 Transition state analysis uses [graphRC](https://github.com/aligfellow/graphRC) for internal coordinate vibrational mode analysis. Given a QM output file (ORCA, Gaussian, etc.), graphRC identifies which bonds are forming or breaking at the transition state with `--ts`. These are rendered as dashed bonds. graphRC is also used to generate TS vibration frames for `--gif-ts` animations.
 
-> **Python.** Most `xyzrender` flags map 1:1 to keyword arguments on `render()` / `render_gif()`. Two things to note here: `--ts` (and `--nci-detect`) are **`load()`** options — `mol = load("sn2.out", ts_detect=True)` — while the *manual* overlay bonds are `render()` kwargs passed as 1-indexed tuples (`ts_bonds=[(1, 2)]`) rather than a `"1-2"` string. See the [Python API guide](../python_api.md) for the load/render split.
+> **Python.** Most `xyzrender` flags map 1:1 to keyword arguments on `render()` / `render_gif()`. Two things to note here: `--ts` (and `--nci-detect`) are **`load()`** options — `mol = load("sn2.out", ts_detect=True)` — while manual overlay bonds are passed to `render()` or `render_gif()` as 1-indexed tuples (`ts_bonds=[(1, 2)]`) rather than a `"1-2"` string. See the [Python API guide](../python_api.md) for the load/render split.
 
 ## Transition states
 

--- a/docs/source/python_api.md
+++ b/docs/source/python_api.md
@@ -330,7 +330,7 @@ from xyzrender import render_gif
 
 render_gif("caffeine.xyz", gif_rot="y")           # rotation GIF
 render_gif("ts.out", gif_ts=True)                  # TS vibration GIF
-render_gif("ts.out", gif_ts=True, ts_bonds=[(1, 6)])  # override detected TS bonds
+render_gif("ts.out", gif_ts=True, ts_bonds=[(1, 6)])  # skip auto-detection; use this TS bond
 render_gif("traj.xyz", gif_trj=True)               # trajectory GIF
 render_gif("mep.xyz", gif_trj=True, trj_bonds=True)  # re-detect bonds per frame
 render_gif("mol.xyz", gif_rot="y", config=cfg)     # with shared style config

--- a/docs/source/python_api.md
+++ b/docs/source/python_api.md
@@ -330,6 +330,7 @@ from xyzrender import render_gif
 
 render_gif("caffeine.xyz", gif_rot="y")           # rotation GIF
 render_gif("ts.out", gif_ts=True)                  # TS vibration GIF
+render_gif("ts.out", gif_ts=True, ts_bonds=[(1, 6)])  # override detected TS bonds
 render_gif("traj.xyz", gif_trj=True)               # trajectory GIF
 render_gif("mep.xyz", gif_trj=True, trj_bonds=True)  # re-detect bonds per frame
 render_gif("mol.xyz", gif_rot="y", config=cfg)     # with shared style config

--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -1478,6 +1478,8 @@ def render_gif(
     trj_bonds: bool = False,
     # --- NCI detection (gif_ts / gif_trj / gif_rot) ---
     detect_nci: bool = False,
+    # --- Manual TS bonds (1-indexed atom numbering) ---
+    ts_bonds: list[tuple[int, int]] | None = None,
     # --- Vector arrows (gif_rot only) ---
     vector: str | Path | dict | list[VectorArrow] | None = None,
     vector_scale: float | None = None,
@@ -1544,6 +1546,9 @@ def render_gif(
         Mutually exclusive with *gif_rot*.
     gif_ts:
         Transition-state vibration animation (requires ``xyzrender[ts]``).
+    ts_bonds:
+        Manual transition-state bond pairs using 1-indexed atom numbers.
+        In *gif_ts* mode these replace graphRC's detected TS bonds.
     output:
         Output ``.gif`` path.  Defaults to ``<stem>.gif`` beside *molecule*.
     gif_fps:
@@ -1696,6 +1701,8 @@ def render_gif(
 
     if haptic:
         cfg.haptic = True
+
+    _apply_render_overlays(cfg, _gif_graph, ts_bonds=ts_bonds)
 
     if opacity is not None and overlay is None:
         cfg.surface_opacity = opacity

--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -1549,7 +1549,7 @@ def render_gif(
         Transition-state vibration animation (requires ``xyzrender[ts]``).
     ts_bonds:
         Manual transition-state bond pairs using 1-indexed atom numbers.
-        In *gif_ts* mode these replace graphRC's detected TS bonds.
+        In *gif_ts* mode, supplying this skips automatic TS identification.
     output:
         Output ``.gif`` path.  Defaults to ``<stem>.gif`` beside *molecule*.
     gif_fps:
@@ -1829,6 +1829,7 @@ def render_gif(
             ts_frame=ts_frame,
             reference_graph=reference_graph,
             detect_nci=detect_nci,
+            auto_detect_ts=ts_bonds is None and not cfg.ts_bonds,
             axis=_vib_axis,
             n_frames=rot_frames if _vib_axis else None,
             bounce_degrees=float(bounce_deg) if bounce_deg is not None else None,

--- a/src/xyzrender/cli.py
+++ b/src/xyzrender/cli.py
@@ -1124,7 +1124,7 @@ def main() -> None:
             p.error(f"GIF output must have .gif extension, got: .{gif_ext}")
 
     # --- Load molecule ---
-    needs_ts = args.ts_detect or args.gif_ts
+    needs_ts = (args.ts_detect or args.gif_ts) and not cfg.ts_bonds
     if is_cube and needs_ts:
         logger.warning(
             "--ts/--gif-ts has no effect with cube files (single geometry, no frequency data). "

--- a/src/xyzrender/gif.py
+++ b/src/xyzrender/gif.py
@@ -162,22 +162,16 @@ def _copy_ts_nci_attrs(target: "nx.Graph", reference: "nx.Graph") -> None:
                     target[u][v][attr] = d[attr]
 
 
-def _clear_detected_ts_bonds(ts_graph: "nx.Graph", ts_bonds: list[tuple[int, int]]) -> None:
-    """Clear graphRC's TS selection when manual renderer bonds are present."""
-    if not ts_bonds:
-        return
-
+def _validate_manual_ts_bonds(ts_graph: "nx.Graph", ts_bonds: list[tuple[int, int]]) -> None:
+    """Validate renderer-only TS pairs against the vibration graph."""
     n_atoms = ts_graph.number_of_nodes()
     for i, j in ts_bonds:
         if i == j:
             msg = f"--ts-bond cannot connect atom {i + 1} to itself"
             raise ValueError(msg)
-        if i not in ts_graph or j not in ts_graph:
+        if not (0 <= i < n_atoms and 0 <= j < n_atoms):
             msg = f"--ts-bond pair ({i + 1}, {j + 1}) out of range for molecule with {n_atoms} atoms"
             raise ValueError(msg)
-
-    for _u, _v, d in ts_graph.edges(data=True):
-        d.pop("TS", None)
 
 
 def render_vibration_gif(
@@ -196,11 +190,14 @@ def render_vibration_gif(
     bounce_degrees: float | None = None,
     reference_graph: nx.Graph | None = None,
     detect_nci: bool = False,
+    auto_detect_ts: bool | None = None,
 ) -> None:
     """Render a TS vibrational mode as an animated GIF.
 
     Uses graphRC to generate the trajectory, renders each frame as SVG
     with TS bonds dashed, converts to PNG via cairosvg, and stitches into a GIF.
+    Automatic mode uses graphRC's TS identification; manual mode loads only
+    the trajectory and builds ordinary topology with xyzgraph.
 
     If ``reference_graph`` is provided (e.g. from ``-V`` viewer rotation),
     all frames are rotated to match that orientation.
@@ -212,30 +209,49 @@ def render_vibration_gif(
     between ±``bounce_degrees`` over the full frame range instead of a
     linear 360° sweep.
     """
-    try:
-        from graphrc import run_vib_analysis
-    except ImportError:
-        msg = "Vibration GIF requires graphrc"
-        raise ImportError(msg) from None
-
     vib_kwargs = {}
     if vib_frames is not None:
         vib_kwargs["n_frames"] = vib_frames
-    results = run_vib_analysis(
-        input_file=path,
-        mode=mode,
-        ts_frame=ts_frame,
-        enable_graph=True,
-        charge=charge,
-        multiplicity=multiplicity,
-        print_output=False,
-        **vib_kwargs,
-    )
+    if auto_detect_ts is None:
+        auto_detect_ts = not config.ts_bonds
 
-    ts_graph = results["graph"]["ts_graph"]
-    frames = results["trajectory"]["frames"]
+    if not auto_detect_ts:
+        try:
+            from graphrc import load_trajectory
+        except ImportError:
+            msg = "Vibration GIF requires graphrc"
+            raise ImportError(msg) from None
 
-    _clear_detected_ts_bonds(ts_graph, config.ts_bonds)
+        trajectory = load_trajectory(path, mode=mode, print_output=False, **vib_kwargs)
+        frames = trajectory["frames"]
+
+        from xyzgraph import build_graph
+
+        ts_data = frames[ts_frame]
+        atoms = list(zip(ts_data["symbols"], [tuple(p) for p in ts_data["positions"]], strict=True))
+        ts_graph = build_graph(atoms, charge=charge, multiplicity=multiplicity)
+    else:
+        try:
+            from graphrc import run_vib_analysis
+        except ImportError:
+            msg = "Vibration GIF requires graphrc"
+            raise ImportError(msg) from None
+
+        results = run_vib_analysis(
+            input_file=path,
+            mode=mode,
+            ts_frame=ts_frame,
+            enable_graph=True,
+            charge=charge,
+            multiplicity=multiplicity,
+            print_output=False,
+            **vib_kwargs,
+        )
+        ts_graph = results["graph"]["ts_graph"]
+        frames = results["trajectory"]["frames"]
+
+    if not auto_detect_ts:
+        _validate_manual_ts_bonds(ts_graph, config.ts_bonds)
 
     # NCI: detect once on TS geometry, apply to all frames
     fixed_ncis = None

--- a/src/xyzrender/gif.py
+++ b/src/xyzrender/gif.py
@@ -162,6 +162,24 @@ def _copy_ts_nci_attrs(target: "nx.Graph", reference: "nx.Graph") -> None:
                     target[u][v][attr] = d[attr]
 
 
+def _clear_detected_ts_bonds(ts_graph: "nx.Graph", ts_bonds: list[tuple[int, int]]) -> None:
+    """Clear graphRC's TS selection when manual renderer bonds are present."""
+    if not ts_bonds:
+        return
+
+    n_atoms = ts_graph.number_of_nodes()
+    for i, j in ts_bonds:
+        if i == j:
+            msg = f"--ts-bond cannot connect atom {i + 1} to itself"
+            raise ValueError(msg)
+        if i not in ts_graph or j not in ts_graph:
+            msg = f"--ts-bond pair ({i + 1}, {j + 1}) out of range for molecule with {n_atoms} atoms"
+            raise ValueError(msg)
+
+    for _u, _v, d in ts_graph.edges(data=True):
+        d.pop("TS", None)
+
+
 def render_vibration_gif(
     path: str,
     config: RenderConfig,
@@ -216,6 +234,8 @@ def render_vibration_gif(
 
     ts_graph = results["graph"]["ts_graph"]
     frames = results["trajectory"]["frames"]
+
+    _clear_detected_ts_bonds(ts_graph, config.ts_bonds)
 
     # NCI: detect once on TS geometry, apply to all frames
     fixed_ncis = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,6 +150,37 @@ def test_gif_diffuse_ts_incompatible():
     assert result.returncode != 0
 
 
+def test_gif_ts_manual_bonds_skip_auto_ts_load(monkeypatch, tmp_path):
+    import sys
+    from unittest.mock import patch
+
+    from xyzrender import api
+    from xyzrender.cli import main
+
+    source = _STRUCTURES / "sn2.out"
+    argv = [
+        "xyzrender",
+        str(source),
+        "--gif-ts",
+        "--ts-bond",
+        "1-3",
+        "-o",
+        str(tmp_path / "ts.svg"),
+        "-go",
+        str(tmp_path / "ts.gif"),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with (
+        patch.object(api, "load", wraps=api.load) as mock_load,
+        patch.object(api, "render"),
+        patch.object(api, "render_gif"),
+    ):
+        main()
+
+    assert mock_load.call_args_list[0].kwargs["ts_detect"] is False
+
+
 def test_hl_too_many_args():
     """--hl with >2 arguments should error."""
     result = _run_cli(str(_CAFFEINE), "--hl", "1-5", "red", "extra", expect_error=True)

--- a/tests/test_gif.py
+++ b/tests/test_gif.py
@@ -120,6 +120,116 @@ def test_rotate_frames_preserves_extra_keys():
     assert out[0]["hull_opacity_factor"] == 0.8
 
 
+def test_clear_detected_ts_bonds_overrides_auto():
+    import networkx as nx
+
+    from xyzrender.gif import _clear_detected_ts_bonds
+
+    g = nx.Graph()
+    g.add_edge(0, 1, TS=True)
+    g.add_edge(1, 2, TS=True)
+    g.add_edge(3, 4)
+
+    _clear_detected_ts_bonds(g, [(0, 1)])
+
+    assert "TS" not in g[0][1]
+    assert "TS" not in g[1][2]
+    assert "TS" not in g[3][4]
+
+
+def test_clear_detected_ts_bonds_does_not_change_topology():
+    import networkx as nx
+
+    from xyzrender.gif import _clear_detected_ts_bonds
+
+    g = nx.Graph([(0, 1), (1, 2)])
+    g[0][1]["TS"] = True
+
+    _clear_detected_ts_bonds(g, [(0, 2)])
+
+    assert set(g.edges) == {(0, 1), (1, 2)}
+    assert "TS" not in g[0][1]
+
+
+@pytest.mark.parametrize("pair", [(0, 0), (0, 3)])
+def test_clear_detected_ts_bonds_rejects_invalid_pair(pair):
+    import networkx as nx
+
+    from xyzrender.gif import _clear_detected_ts_bonds
+
+    g = nx.Graph([(0, 1), (1, 2)])
+
+    with pytest.raises(ValueError, match="--ts-bond"):
+        _clear_detected_ts_bonds(g, [pair])
+
+
+def test_clear_detected_ts_bonds_noop_when_empty():
+    import networkx as nx
+
+    from xyzrender.gif import _clear_detected_ts_bonds
+
+    g = nx.Graph()
+    g.add_edge(0, 1, TS=True)
+
+    _clear_detected_ts_bonds(g, [])
+
+    assert g[0][1].get("TS") is True
+
+
+def test_render_vibration_gif_uses_manual_ts_bonds(tmp_path):
+    from unittest.mock import patch
+
+    import networkx as nx
+
+    from xyzrender.gif import render_vibration_gif
+    from xyzrender.types import RenderConfig
+
+    graph = nx.Graph()
+    for i in range(3):
+        graph.add_node(i, symbol="C", position=(float(i), 0.0, 0.0))
+    graph.add_edge(0, 1, TS=True)
+    graph.add_edge(1, 2, TS=True)
+    frames = [{"symbols": ["C", "C", "C"], "positions": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]}]
+    analysis = {"graph": {"ts_graph": graph}, "trajectory": {"frames": frames}}
+    captured = {}
+
+    def _capture(render_graph, _frames, config, **_kwargs):
+        captured["graph"] = render_graph
+        captured["config"] = config
+        return [b""]
+
+    with (
+        patch("graphrc.run_vib_analysis", return_value=analysis),
+        patch("xyzrender.gif._render_frames", side_effect=_capture),
+        patch("xyzrender.gif._stitch_gif"),
+    ):
+        render_vibration_gif(
+            "ts.out",
+            RenderConfig(auto_orient=False, ts_bonds=[(0, 2)]),
+            str(tmp_path / "ts.gif"),
+        )
+
+    assert all("TS" not in data for _i, _j, data in captured["graph"].edges(data=True))
+    assert not captured["graph"].has_edge(0, 2)
+    assert captured["config"].ts_bonds == [(0, 2)]
+
+
+def test_render_gif_ts_accepts_manual_ts_bonds(tmp_path):
+    from unittest.mock import patch
+
+    from xyzrender import render_gif
+
+    with patch("xyzrender.gif.render_vibration_gif") as mock_render:
+        render_gif(
+            STRUCTURES / "sn2.out",
+            gif_ts=True,
+            ts_bonds=[(1, 3)],
+            output=tmp_path / "ts.gif",
+        )
+
+    assert mock_render.call_args.kwargs["config"].ts_bonds == [(0, 2)]
+
+
 def test_render_trajectory_gif_trj_bonds(tmp_path):
     """trj_bonds=True must rebuild graphs per frame, and those graphs must
     survive the orient/rotate transforms and reach the worker."""

--- a/tests/test_gif.py
+++ b/tests/test_gif.py
@@ -120,114 +120,67 @@ def test_rotate_frames_preserves_extra_keys():
     assert out[0]["hull_opacity_factor"] == 0.8
 
 
-def test_clear_detected_ts_bonds_overrides_auto():
-    import networkx as nx
-
-    from xyzrender.gif import _clear_detected_ts_bonds
-
-    g = nx.Graph()
-    g.add_edge(0, 1, TS=True)
-    g.add_edge(1, 2, TS=True)
-    g.add_edge(3, 4)
-
-    _clear_detected_ts_bonds(g, [(0, 1)])
-
-    assert "TS" not in g[0][1]
-    assert "TS" not in g[1][2]
-    assert "TS" not in g[3][4]
-
-
-def test_clear_detected_ts_bonds_does_not_change_topology():
-    import networkx as nx
-
-    from xyzrender.gif import _clear_detected_ts_bonds
-
-    g = nx.Graph([(0, 1), (1, 2)])
-    g[0][1]["TS"] = True
-
-    _clear_detected_ts_bonds(g, [(0, 2)])
-
-    assert set(g.edges) == {(0, 1), (1, 2)}
-    assert "TS" not in g[0][1]
-
-
-@pytest.mark.parametrize("pair", [(0, 0), (0, 3)])
-def test_clear_detected_ts_bonds_rejects_invalid_pair(pair):
-    import networkx as nx
-
-    from xyzrender.gif import _clear_detected_ts_bonds
-
-    g = nx.Graph([(0, 1), (1, 2)])
-
-    with pytest.raises(ValueError, match="--ts-bond"):
-        _clear_detected_ts_bonds(g, [pair])
-
-
-def test_clear_detected_ts_bonds_noop_when_empty():
-    import networkx as nx
-
-    from xyzrender.gif import _clear_detected_ts_bonds
-
-    g = nx.Graph()
-    g.add_edge(0, 1, TS=True)
-
-    _clear_detected_ts_bonds(g, [])
-
-    assert g[0][1].get("TS") is True
-
-
-def test_render_vibration_gif_uses_manual_ts_bonds(tmp_path):
+@pytest.mark.parametrize(
+    ("ts_bonds", "auto_detect", "expected"),
+    [(None, True, []), ([], False, []), ([(1, 3)], False, [(0, 2)])],
+)
+def test_render_gif_ts_detection_mode(tmp_path, ts_bonds, auto_detect, expected):
     from unittest.mock import patch
 
     import networkx as nx
 
-    from xyzrender.gif import render_vibration_gif
-    from xyzrender.types import RenderConfig
+    from xyzrender import render_gif
 
-    graph = nx.Graph()
-    for i in range(3):
-        graph.add_node(i, symbol="C", position=(float(i), 0.0, 0.0))
-    graph.add_edge(0, 1, TS=True)
-    graph.add_edge(1, 2, TS=True)
-    frames = [{"symbols": ["C", "C", "C"], "positions": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]}]
-    analysis = {"graph": {"ts_graph": graph}, "trajectory": {"frames": frames}}
-    captured = {}
-
-    def _capture(render_graph, _frames, config, **_kwargs):
-        captured["graph"] = render_graph
-        captured["config"] = config
-        return [b""]
+    frames = [{"symbols": ["C", "C", "C"], "positions": [[0, 0, 0], [1.4, 0, 0], [2.8, 0, 0]]}]
+    auto_graph = nx.Graph()
+    auto_graph.add_nodes_from(
+        (i, {"symbol": "C", "position": tuple(position)}) for i, position in enumerate(frames[0]["positions"])
+    )
+    auto_graph.add_edge(0, 1, TS=True)
+    analysis = {"graph": {"ts_graph": auto_graph}, "trajectory": {"frames": frames}}
 
     with (
-        patch("graphrc.run_vib_analysis", return_value=analysis),
-        patch("xyzrender.gif._render_frames", side_effect=_capture),
+        patch("graphrc.load_trajectory", return_value={"frames": frames}) as mock_load,
+        patch("graphrc.run_vib_analysis", return_value=analysis) as mock_analysis,
+        patch("xyzrender.gif._render_frames", return_value=[b""]) as mock_render,
         patch("xyzrender.gif._stitch_gif"),
     ):
-        render_vibration_gif(
-            "ts.out",
-            RenderConfig(auto_orient=False, ts_bonds=[(0, 2)]),
-            str(tmp_path / "ts.gif"),
+        render_gif(
+            STRUCTURES / "sn2.out",
+            gif_ts=True,
+            ts_bonds=ts_bonds,
+            vib_frames=4,
+            orient=False,
+            output=tmp_path / "ts.gif",
         )
 
-    assert all("TS" not in data for _i, _j, data in captured["graph"].edges(data=True))
-    assert not captured["graph"].has_edge(0, 2)
-    assert captured["config"].ts_bonds == [(0, 2)]
+    assert mock_analysis.call_count == int(auto_detect)
+    assert mock_load.call_count == int(not auto_detect)
+    graph, _frames, config = mock_render.call_args.args
+    assert any(data.get("TS") for _i, _j, data in graph.edges(data=True)) is auto_detect
+    assert config.ts_bonds == expected
 
 
-def test_render_gif_ts_accepts_manual_ts_bonds(tmp_path):
+@pytest.mark.parametrize("ts_bonds", [[(1, 1)], [(1, 999)]])
+def test_render_gif_ts_rejects_invalid_manual_bonds(tmp_path, ts_bonds):
     from unittest.mock import patch
 
     from xyzrender import render_gif
 
-    with patch("xyzrender.gif.render_vibration_gif") as mock_render:
+    frames = [{"symbols": ["C", "C"], "positions": [[0, 0, 0], [1.4, 0, 0]]}]
+    with (
+        patch("graphrc.load_trajectory", return_value={"frames": frames}),
+        patch("graphrc.run_vib_analysis", side_effect=AssertionError("automatic TS identification ran")),
+        pytest.raises(ValueError, match="ts-bond"),
+    ):
         render_gif(
             STRUCTURES / "sn2.out",
             gif_ts=True,
-            ts_bonds=[(1, 3)],
+            ts_bonds=ts_bonds,
+            vib_frames=4,
+            orient=False,
             output=tmp_path / "ts.gif",
         )
-
-    assert mock_render.call_args.kwargs["config"].ts_bonds == [(0, 2)]
 
 
 def test_render_trajectory_gif_trj_bonds(tmp_path):


### PR DESCRIPTION
Adds manual transition-state bond selection to vibration GIFs. When `--ts-bond` is used with `--gif-ts`, the selected bonds replace the automatically detected TS bonds. The same option is also available through the Python API.
