### PR TITLE
Match CLI behavior for boolean GIF rotation

### DIFF
--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -1387,7 +1387,7 @@ def render(
 def render_gif(
     molecule: str | os.PathLike | Molecule,
     *,
-    gif_rot: str | None = None,
+    gif_rot: str | bool | None = None,
     gif_bounce: float | tuple[float, str] | None = None,
     gif_trj: bool = False,
     gif_ts: bool = False,
@@ -1534,7 +1534,8 @@ def render_gif(
         trajectory or vibration data is read directly from disk).
     gif_rot:
         Rotation axis: ``"x"``, ``"y"``, ``"z"``, diagonal (``"xy"``,
-        …), or a 3-digit Miller index (``"111"``).
+        …), or a 3-digit Miller index (``"111"``). Pass ``True`` to use
+        the default ``"y"`` axis.
     gif_trj:
         Trajectory animation — *molecule* must be a multi-frame XYZ.
     gif_bounce:
@@ -1568,6 +1569,9 @@ def render_gif(
         render_trajectory_gif,
         render_vibration_gif,
     )
+
+    if isinstance(gif_rot, bool):
+        gif_rot = "y" if gif_rot else None
 
     if isinstance(gif_bounce, tuple):
         bounce_deg, bounce_ax = gif_bounce

--- a/tests/test_gif.py
+++ b/tests/test_gif.py
@@ -179,16 +179,10 @@ def test_api_render_gif_rotation_true_uses_y_axis(tmp_path):
 
     from xyzrender import render_gif
 
-    axes = []
-
-    def _capture_axis(*, axis, **_):
-        axes.append(axis)
-
-    with patch("xyzrender.gif.render_rotation_gif", side_effect=_capture_axis):
+    with patch("xyzrender.gif.render_rotation_gif") as mock_render:
         render_gif(_tiny_molecule(), gif_rot=True, output=tmp_path / "true.gif")
-        render_gif(_tiny_molecule(), gif_rot="y", output=tmp_path / "y.gif")
 
-    assert axes == ["y", "y"]
+    assert mock_render.call_args.kwargs["axis"] == "y"
 
 
 def test_api_render_gif_bounce(tmp_path):

--- a/tests/test_gif.py
+++ b/tests/test_gif.py
@@ -174,6 +174,23 @@ def test_api_render_gif_rotation(tmp_path):
     assert result.path.exists()
 
 
+def test_api_render_gif_rotation_true_uses_y_axis(tmp_path):
+    from unittest.mock import patch
+
+    from xyzrender import render_gif
+
+    axes = []
+
+    def _capture_axis(*, axis, **_):
+        axes.append(axis)
+
+    with patch("xyzrender.gif.render_rotation_gif", side_effect=_capture_axis):
+        render_gif(_tiny_molecule(), gif_rot=True, output=tmp_path / "true.gif")
+        render_gif(_tiny_molecule(), gif_rot="y", output=tmp_path / "y.gif")
+
+    assert axes == ["y", "y"]
+
+
 def test_api_render_gif_bounce(tmp_path):
     pytest.importorskip("cairosvg", reason="cairosvg required")
     from xyzrender import render_gif


### PR DESCRIPTION
Updates the Python GIF API so `gif_rot=True` uses the default y-axis, matching the CLI’s bare `--gif-rot` behavior. Explicit axes and disabled rotation continue to behave as before.

Fixes #163.
