### PR TITLE
Fix notebook SVG ID collisions

### DIFF
--- a/src/xyzrender/renderer.py
+++ b/src/xyzrender/renderer.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import itertools
 import logging
-import threading
 from typing import NamedTuple
+from uuid import uuid4
 
 import networkx as nx
 import numpy as np
@@ -42,16 +42,6 @@ from xyzrender.types import BondStyle, RenderConfig
 from xyzrender.utils import pca_orient
 
 logger = logging.getLogger(__name__)
-
-_render_counter = itertools.count()  # unique ID prefix per render call (SVG ids are global in Jupyter HTML)
-_render_counter_lock = threading.Lock()
-
-
-def _next_render_id() -> int:
-    """Atomic increment of the SVG id counter — safe under free-threaded Python."""
-    with _render_counter_lock:
-        return next(_render_counter)
-
 
 _RADIUS_SCALE = 0.075  # VdW → atoms display radius
 _REF_SPAN = 6.0  # reference molecular span (Å) for proportional bond/stroke scaling
@@ -1849,13 +1839,9 @@ def render_svg(graph, config: RenderConfig | None = None, *, _log: bool = True, 
 
     svg.append("</svg>")
     raw = "\n".join(svg)
-    # SVG id= values are global in an HTML document — multiple renders in the same
-    # Jupyter notebook page collide, causing atoms/gradients from the first render to
-    # appear in all subsequent ones.  Prefix every id, href, and url() reference with
-    # a unique token so each SVG is self-contained regardless of embedding context.
-    # Skip when _unique_ids=False (GIF frames: converted to PNG immediately, never shown as SVG).
+    # Prefix document-global SVG IDs so notebook outputs cannot affect one another.
     if _unique_ids:
-        p = f"x{_next_render_id()}"
+        p = f"x{uuid4().hex}"
         raw = raw.replace('id="', f'id="{p}')
         raw = raw.replace('href="#', f'href="#{p}')
         raw = raw.replace("url(#", f"url(#{p}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,9 @@ Overlays and style params are tested in combinations where possible to
 minimise the number of full render calls.
 """
 
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 import networkx as nx
@@ -83,6 +86,25 @@ def test_svgresult_str(caffeine):
 def test_svgresult_jupyter_display(caffeine):
     result = render(caffeine, orient=False)
     assert result._repr_svg_().startswith("<svg")
+
+
+def test_render_svg_ids_are_unique_across_processes():
+    structure = STRUCTURES / "ethanol.xyz"
+    src = Path(__file__).parent.parent / "src"
+    script = (
+        f"import sys; sys.path.insert(0, {str(src)!r}); "
+        "from xyzrender import load, render; "
+        f"print(render(load({str(structure)!r}), orient=False, gradient=True)._repr_svg_())"
+    )
+
+    svgs = [
+        subprocess.run([sys.executable, "-c", script], check=True, capture_output=True, text=True).stdout
+        for _ in range(2)
+    ]
+    id_sets = [set(re.findall(r'id="([^"]+)', svg)) for svg in svgs]
+
+    assert id_sets[0]
+    assert id_sets[0].isdisjoint(id_sets[1])
 
 
 def test_svgresult_save(caffeine, tmp_path):

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -11,8 +11,8 @@ from xyzrender import load, render
 
 
 def _strip_svg_ids(svg: str) -> str:
-    """Strip render-counter IDs so SVGs from different render() calls can be compared."""
-    return re.sub(r'id="x\d+', 'id="x0', re.sub(r"url\(#x\d+", "url(#x0", svg))
+    """Normalize render IDs so SVGs from different render() calls can be compared."""
+    return re.sub(r"x[0-9a-f]{32}", "x0", svg)
 
 
 STRUCTURES = Path(__file__).parent.parent / "examples" / "structures"


### PR DESCRIPTION
Uses globally unique SVG ID prefixes so inline notebook renders cannot reuse gradient or definition IDs from earlier outputs.

  Fixes #162.