### PR TITLE
Add NCI type filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,17 @@ Full usage, the Python API guide, every flag, and runnable examples live in the 
 |---------------------|----------------|--------------------|
 | ![ensemble](examples/images/triphenylbenzol_ensemble.svg) | ![ensemble cpk](examples/images/triphenylbenzol_ensemble_cpk.svg) | ![ensemble custom](examples/images/triphenylbenzol_ensemble_custom.svg) |
 
-### Transition states & NCI
+### Transition states
 
-| Auto TS | Manual TS | Auto NCI | Selected NCI (`--nci hb`) | TS + NCI custom colours | QM output |
-|---------|-----------|----------|---------------------------|-------------------------|-----------|
-| ![ts](examples/images/sn2_ts.svg) | ![ts man](examples/images/sn2_ts_man.svg) | ![nci](examples/images/nci.svg) | ![hydrogen-bond NCIs](examples/images/bimp_nci_hb.svg) | ![ts nci custom](examples/images/bimp_ts_nci_custom.svg) | ![bimp](examples/images/bimp_qm.svg) |
+| Auto TS | Manual TS | QM output |
+|---------|-----------|-----------|
+| ![ts](examples/images/sn2_ts.svg) | ![ts man](examples/images/sn2_ts_man.svg) | ![bimp](examples/images/bimp_qm.svg) |
+
+### NCIs
+
+| Auto NCI | Selected NCI (`--nci hb`) | TS + NCI custom colours |
+|----------|---------------------------|-------------------------|
+| ![nci](examples/images/nci.svg) | ![hydrogen-bond NCIs](examples/images/bimp_nci_hb.svg) | ![ts nci custom](examples/images/bimp_ts_nci_custom.svg) |
 
 ### Annotations & labels
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ Full usage, the Python API guide, every flag, and runnable examples live in the 
 
 ### Transition states & NCI
 
-| Auto TS | Manual TS | Auto NCI | TS + NCI custom colours | QM output |
-|---------|-----------|----------|-------------------------|-----------|
-| ![ts](examples/images/sn2_ts.svg) | ![ts man](examples/images/sn2_ts_man.svg) | ![nci](examples/images/nci.svg) | ![ts nci custom](examples/images/bimp_ts_nci_custom.svg) | ![bimp](examples/images/bimp_qm.svg) |
+| Auto TS | Manual TS | Auto NCI | Selected NCI (`--nci hb`) | TS + NCI custom colours | QM output |
+|---------|-----------|----------|---------------------------|-------------------------|-----------|
+| ![ts](examples/images/sn2_ts.svg) | ![ts man](examples/images/sn2_ts_man.svg) | ![nci](examples/images/nci.svg) | ![hydrogen-bond NCIs](examples/images/bimp_nci_hb.svg) | ![ts nci custom](examples/images/bimp_ts_nci_custom.svg) | ![bimp](examples/images/bimp_qm.svg) |
 
 ### Annotations & labels
 

--- a/docs/source/cli_reference.md
+++ b/docs/source/cli_reference.md
@@ -101,7 +101,7 @@ These flags draw graph-detected bond overlays (dashes / dots) on top of the mole
 | `--ts-element` / `--no-ts-element` | Atom-coloured halves on TS dashes |
 | `--ts-dash LEN,GAP` | TS dash length,gap as bond-width multiples (default `1.2,2.2`) |
 | `--ts-width MULT` | TS line width as a bond-width multiple (default `1.2`) |
-| `--nci` | Auto-detect NCI interactions (graph topology, not the volumetric surface — see `--nci-surf`) |
+| `--nci [TYPES]` | Auto-detect all NCIs, or select comma-separated exact types / `hb`, `pi`, and `ion` groups (graph topology, not the volumetric surface — see `--nci-surf`) |
 | `--nci-bond PAIR` | Manual NCI bond pair(s) (1-indexed) |
 | `--nci-color` | Colour for dotted NCI/haptic bonds (hex or named); overrides `--nci-element` |
 | `--nci-element` / `--no-nci-element` | Atom-coloured halves on NCI/haptic dots (on in pmol/btube/tube/mtube) |

--- a/docs/source/examples/ts_nci.md
+++ b/docs/source/examples/ts_nci.md
@@ -41,7 +41,9 @@ xyzrender mn-h2.log --ts -o mn-h2_qm.svg
 
 ## NCI interactions (`--nci`)
 
-`--nci` uses [xyzgraph](https://github.com/aligfellow/xyzgraph)'s `detect_ncis` to identify hydrogen bonds, halogen bonds, pi-stacking, and other non-covalent interactions from geometry. These are rendered as dotted bonds.
+`--nci` uses [xyzgraph](https://github.com/aligfellow/xyzgraph)'s `detect_ncis` to identify hydrogen bonds, halogen bonds, pi-stacking, and other non-covalent interactions from geometry. These are rendered as dotted bonds. With no value it shows every detected interaction; an optional comma-separated value selects exact xyzgraph types or the `hb`, `pi`, and `ion` groups.
+
+The `hb` group includes hydrogen-bond types, `pi` includes interactions involving a pi system, and `ion` includes cation, anion, ionic, and salt-bridge interactions. Exact names such as `hbond` select only that xyzgraph type.
 
 For pi-system interactions (e.g. pi-stacking, cation-pi), centroid dummy nodes are placed at the mean position of the pi-system atoms. For trajectory GIFs with `--nci`, interactions are re-detected per frame.
 
@@ -51,6 +53,8 @@ For pi-system interactions (e.g. pi-stacking, cation-pi), centroid dummy nodes a
 
 ```bash
 xyzrender Hbond.xyz --hy --nci -o nci.svg                 # auto-detect all NCI
+xyzrender bimp.xyz --nci hb,pi -o selected_nci.svg        # hydrogen-bond and pi groups
+xyzrender Hbond.xyz --nci hbond -o hbond.svg              # one exact xyzgraph type
 xyzrender Hbond.xyz --hy --nci-bond "8-9" -o nci_man.svg  # specific bond only
 xyzrender Hbond.xyz --hy --nci --nci-color teal -o nci_teal.svg
 ```
@@ -58,6 +62,10 @@ xyzrender Hbond.xyz --hy --nci --nci-color teal -o nci_teal.svg
 ```python
 mol = load("Hbond.xyz", nci_detect=True)          # equivalent to --nci at load-time
 render(mol, hy=True, output="nci.svg")
+
+mol = load("bimp.xyz", nci_detect="hb,pi")       # selected groups at load-time
+render(load("bimp.xyz"), detect_nci=["hb", "pi"])
+render_gif("trajectory.xyz", gif_trj=True, detect_nci="ion")
 
 render("Hbond.xyz", nci_bonds=[(8, 9)], hy=True)  # 1-indexed tuple list
 ```

--- a/docs/source/examples/ts_nci.md
+++ b/docs/source/examples/ts_nci.md
@@ -53,7 +53,7 @@ For pi-system interactions (e.g. pi-stacking, cation-pi), centroid dummy nodes a
 
 ```bash
 xyzrender Hbond.xyz --hy --nci -o nci.svg                 # auto-detect all NCI
-xyzrender bimp.xyz --nci hb,pi -o selected_nci.svg        # hydrogen-bond and pi groups
+xyzrender bimp.out --nci hb,pi -o selected_nci.svg        # hydrogen-bond and pi groups
 xyzrender Hbond.xyz --nci hbond -o hbond.svg              # one exact xyzgraph type
 xyzrender Hbond.xyz --hy --nci-bond "8-9" -o nci_man.svg  # specific bond only
 xyzrender Hbond.xyz --hy --nci --nci-color teal -o nci_teal.svg
@@ -63,8 +63,8 @@ xyzrender Hbond.xyz --hy --nci --nci-color teal -o nci_teal.svg
 mol = load("Hbond.xyz", nci_detect=True)          # equivalent to --nci at load-time
 render(mol, hy=True, output="nci.svg")
 
-mol = load("bimp.xyz", nci_detect="hb,pi")       # selected groups at load-time
-render(load("bimp.xyz"), detect_nci=["hb", "pi"])
+mol = load("bimp.out", nci_detect="hb,pi")       # selected groups at load-time
+render(load("bimp.out"), detect_nci=["hb", "pi"])
 render_gif("trajectory.xyz", gif_trj=True, detect_nci="ion")
 
 render("Hbond.xyz", nci_bonds=[(8, 9)], hy=True)  # 1-indexed tuple list

--- a/docs/source/python_api.md
+++ b/docs/source/python_api.md
@@ -26,7 +26,7 @@ The CLI runs everything in one command, but the Python API separates **parsing**
 
 * **`load()` options** change how the file is *parsed* and must be passed to `load()`:
   `smiles`, `charge`, `multiplicity`, `kekule`, `rebuild`, `mol_frame`, `bohr`, `quick`,
-  `ts_detect` (`--ts`), `ts_frame`, `nci_detect` (`--nci-detect`), `cell` (`--cell`),
+  `ts_detect` (`--ts`), `ts_frame`, `nci_detect` (`--nci`), `cell` (`--cell`),
   and all `ensemble*` options (`--ensemble`, `--ensemble-color`, `--align-atoms`, `--max-frames`, …).
 * **`render()` / `render_gif()` options** change how the parsed molecule is *drawn* — everything else
   (styling, bond rules, surfaces, overlays, hulls, annotations, output).
@@ -46,6 +46,7 @@ Use `load()` keyword arguments for non-default loading behaviour:
 ```python
 mol = load("ts.out", ts_detect=True)            # detect TS bonds via graphRC
 mol = load("mol.xyz", nci_detect=True)          # detect NCI interactions
+mol = load("mol.xyz", nci_detect="hb,pi")       # select NCI groups
 mol = load("mol.sdf", mol_frame=2, kekule=True) # SDF frame + Kekule bonds
 mol = load("CC(=O)O", smiles=True)              # SMILES → 3D (requires rdkit)
 mol = load(rdkit_mol)                           # RDKit Mol w/ embedded confs; ensemble=True overlays all
@@ -57,6 +58,14 @@ mol = load("mol.xyz", quick=True)               # skip BO detection (faster, use
 ## Render options
 
 Render-time CLI flags are available as keyword arguments to `render()`:
+
+Automatic NCI detection can also be requested at render time without changing the loaded molecule. `True` selects all interactions; exact xyzgraph type names or the `hb`, `pi`, and `ion` groups can be supplied as a comma-separated string or list. `render_gif()` accepts the same `detect_nci` values.
+
+```python
+render(mol, detect_nci="hbond")
+render(mol, detect_nci=["hb", "pi"])
+render_gif("trajectory.xyz", gif_trj=True, detect_nci="ion")
+```
 
 ### Styling
 

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -55,6 +55,7 @@ echo "=== TS and NCI options ==="
 xyzrender "$DIR/sn2.out" --ts-bond "1-2" -o "$IMG/sn2_ts_man.svg"
 xyzrender "$DIR/sn2.out" --ts --hy -o "$IMG/sn2_ts.svg"
 xyzrender "$DIR/bimp.out" --nci -o "$IMG/bimp_nci.svg"
+xyzrender "$DIR/bimp.out" --nci hb -o "$IMG/bimp_nci_hb.svg"
 xyzrender "$DIR/Hbond.xyz" --hy --nci-bond "8-9" -o "$IMG/nci_man.svg"  # specific NCI bond only
 xyzrender "$DIR/Hbond.xyz" --hy --nci -o "$IMG/nci.svg"  # specific NCI bond only
 xyzrender "$DIR/bimp.out" --ts --nci --vdw "84-169" --ts-color magenta --nci-color teal -o "$IMG/bimp_ts_nci_custom.svg"

--- a/examples/images/bimp_nci_hb.svg
+++ b/examples/images/bimp_nci_hb.svg
@@ -1,0 +1,401 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 800 739" width="800" height="739">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <defs>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g0" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f27a6c"/><stop offset="40%" stop-color="#ff4545"/><stop offset="100%" stop-color="#ac3b51"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g1" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c3c3c3"/><stop offset="40%" stop-color="#b9b9b9"/><stop offset="100%" stop-color="#866f74"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g2" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#71a8ee"/><stop offset="40%" stop-color="#4c68f8"/><stop offset="100%" stop-color="#2639ab"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g3" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bfbfbf"/><stop offset="40%" stop-color="#b5b5b5"/><stop offset="100%" stop-color="#7e666b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g4" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bebebe"/><stop offset="40%" stop-color="#b4b4b4"/><stop offset="100%" stop-color="#7c6369"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g5" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bcbcbc"/><stop offset="40%" stop-color="#b1b1b1"/><stop offset="100%" stop-color="#785e64"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g6" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bbbbbb"/><stop offset="40%" stop-color="#b0b0b0"/><stop offset="100%" stop-color="#765c62"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g7" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bcbcbc"/><stop offset="40%" stop-color="#b1b1b1"/><stop offset="100%" stop-color="#785f64"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g8" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bebebe"/><stop offset="40%" stop-color="#b4b4b4"/><stop offset="100%" stop-color="#7d6469"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g9" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c0c0c0"/><stop offset="40%" stop-color="#b5b5b5"/><stop offset="100%" stop-color="#7f676c"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g10" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c2c2c2"/><stop offset="40%" stop-color="#b8b8b8"/><stop offset="100%" stop-color="#856d72"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g11" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f27365"/><stop offset="40%" stop-color="#ff3c3c"/><stop offset="100%" stop-color="#a83149"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g12" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d2d2d2"/><stop offset="40%" stop-color="#cbcbcb"/><stop offset="100%" stop-color="#a59497"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g13" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d5d5d5"/><stop offset="40%" stop-color="#cecece"/><stop offset="100%" stop-color="#ab9b9e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g14" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d4d4d4"/><stop offset="40%" stop-color="#cdcdcd"/><stop offset="100%" stop-color="#a8989b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g15" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d4d4d4"/><stop offset="40%" stop-color="#cdcdcd"/><stop offset="100%" stop-color="#a9989c"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g16" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d5d5d5"/><stop offset="40%" stop-color="#cecece"/><stop offset="100%" stop-color="#aa9b9e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g17" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d5d5d5"/><stop offset="40%" stop-color="#cecece"/><stop offset="100%" stop-color="#aa9a9e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g18" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d4d4d4"/><stop offset="40%" stop-color="#cdcdcd"/><stop offset="100%" stop-color="#a9989c"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g19" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d3d3d3"/><stop offset="40%" stop-color="#cccccc"/><stop offset="100%" stop-color="#a7969a"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g20" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d3d3d3"/><stop offset="40%" stop-color="#cccccc"/><stop offset="100%" stop-color="#a7969a"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g31" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#a3c7f4"/><stop offset="40%" stop-color="#8b9dfb"/><stop offset="100%" stop-color="#727ec8"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g33" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f7f7ab"/><stop offset="40%" stop-color="#ffff94"/><stop offset="100%" stop-color="#d1b77b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g34" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f8b8b1"/><stop offset="40%" stop-color="#ff9c9c"/><stop offset="100%" stop-color="#d397a3"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g35" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f7b1a9"/><stop offset="40%" stop-color="#ff9393"/><stop offset="100%" stop-color="#ce8d9a"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g36" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bababa"/><stop offset="40%" stop-color="#afafaf"/><stop offset="100%" stop-color="#73595f"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g37" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b7b7b7"/><stop offset="40%" stop-color="#ababab"/><stop offset="100%" stop-color="#6d5258"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g38" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b9b9b9"/><stop offset="40%" stop-color="#aeaeae"/><stop offset="100%" stop-color="#72585e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g39" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b6b6b6"/><stop offset="40%" stop-color="#aaaaaa"/><stop offset="100%" stop-color="#6b4f55"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g41" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b7b7b7"/><stop offset="40%" stop-color="#ababab"/><stop offset="100%" stop-color="#6d5157"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g43" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b6b6b6"/><stop offset="40%" stop-color="#aaaaaa"/><stop offset="100%" stop-color="#6b4f55"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g47" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c6c6c6"/><stop offset="40%" stop-color="#bdbdbd"/><stop offset="100%" stop-color="#8c777b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g48" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cfcfcf"/><stop offset="40%" stop-color="#c7c7c7"/><stop offset="100%" stop-color="#9e8c90"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g49" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c6c6c6"/><stop offset="40%" stop-color="#bdbdbd"/><stop offset="100%" stop-color="#8c777b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g50" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d9d9d9"/><stop offset="40%" stop-color="#d3d3d3"/><stop offset="100%" stop-color="#b3a4a7"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g52" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cecece"/><stop offset="40%" stop-color="#c7c7c7"/><stop offset="100%" stop-color="#9d8b8f"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g54" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d9d9d9"/><stop offset="40%" stop-color="#d3d3d3"/><stop offset="100%" stop-color="#b2a4a7"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g58" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bfbfbf"/><stop offset="40%" stop-color="#b4b4b4"/><stop offset="100%" stop-color="#7d656a"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g59" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bbbbbb"/><stop offset="40%" stop-color="#b0b0b0"/><stop offset="100%" stop-color="#765c62"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g60" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c2c2c2"/><stop offset="40%" stop-color="#b8b8b8"/><stop offset="100%" stop-color="#836c71"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g61" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bababa"/><stop offset="40%" stop-color="#afafaf"/><stop offset="100%" stop-color="#745a60"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g63" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c0c0c0"/><stop offset="40%" stop-color="#b6b6b6"/><stop offset="100%" stop-color="#81696e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g65" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bdbdbd"/><stop offset="40%" stop-color="#b2b2b2"/><stop offset="100%" stop-color="#796065"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g69" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cccccc"/><stop offset="40%" stop-color="#c4c4c4"/><stop offset="100%" stop-color="#988589"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g70" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c5c5c5"/><stop offset="40%" stop-color="#bbbbbb"/><stop offset="100%" stop-color="#8a7478"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g71" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cccccc"/><stop offset="40%" stop-color="#c3c3c3"/><stop offset="100%" stop-color="#978488"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g72" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bfbfbf"/><stop offset="40%" stop-color="#b4b4b4"/><stop offset="100%" stop-color="#7d656a"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g74" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c4c4c4"/><stop offset="40%" stop-color="#bababa"/><stop offset="100%" stop-color="#887176"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g76" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bebebe"/><stop offset="40%" stop-color="#b4b4b4"/><stop offset="100%" stop-color="#7c6469"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g79" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bababa"/><stop offset="40%" stop-color="#aeaeae"/><stop offset="100%" stop-color="#73585e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g83" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#ffffff"/><stop offset="40%" stop-color="#ffffff"/><stop offset="100%" stop-color="#b09599"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g84" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#77acef"/><stop offset="40%" stop-color="#546ef9"/><stop offset="100%" stop-color="#3042af"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g85" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bdbdbd"/><stop offset="40%" stop-color="#b2b2b2"/><stop offset="100%" stop-color="#796066"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g86" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c7c7c7"/><stop offset="40%" stop-color="#bebebe"/><stop offset="100%" stop-color="#8e787d"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g87" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#67a2ed"/><stop offset="40%" stop-color="#3f5df8"/><stop offset="100%" stop-color="#172ba5"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g88" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f1f165"/><stop offset="40%" stop-color="#ffff3c"/><stop offset="100%" stop-color="#ab7c0f"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g89" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c9c9c9"/><stop offset="40%" stop-color="#c0c0c0"/><stop offset="100%" stop-color="#917d81"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g90" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cbcbcb"/><stop offset="40%" stop-color="#c3c3c3"/><stop offset="100%" stop-color="#968287"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g91" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b8b8b8"/><stop offset="40%" stop-color="#adadad"/><stop offset="100%" stop-color="#70555b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g92" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#ffffff"/><stop offset="40%" stop-color="#ffffff"/><stop offset="100%" stop-color="#a7898e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g93" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cfcfcf"/><stop offset="40%" stop-color="#c7c7c7"/><stop offset="100%" stop-color="#9e8c90"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g95" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d2d2d2"/><stop offset="40%" stop-color="#cacaca"/><stop offset="100%" stop-color="#a39296"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g97" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bababa"/><stop offset="40%" stop-color="#afafaf"/><stop offset="100%" stop-color="#745a5f"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g99" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b6b6b6"/><stop offset="40%" stop-color="#aaaaaa"/><stop offset="100%" stop-color="#6b5056"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g100" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d1d1d1"/><stop offset="40%" stop-color="#cacaca"/><stop offset="100%" stop-color="#a39295"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g101" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d4d4d4"/><stop offset="40%" stop-color="#cdcdcd"/><stop offset="100%" stop-color="#a8989b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g102" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d7d7d7"/><stop offset="40%" stop-color="#d0d0d0"/><stop offset="100%" stop-color="#ae9ea2"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g103" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#72a9ee"/><stop offset="40%" stop-color="#4d68f8"/><stop offset="100%" stop-color="#273aab"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g106" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b6b6b6"/><stop offset="40%" stop-color="#aaaaaa"/><stop offset="100%" stop-color="#6b4f55"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g107" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b6b6b6"/><stop offset="40%" stop-color="#aaaaaa"/><stop offset="100%" stop-color="#6b4f55"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g108" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b7b7b7"/><stop offset="40%" stop-color="#ababab"/><stop offset="100%" stop-color="#6d5157"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g109" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d1ecb7"/><stop offset="40%" stop-color="#c6efa5"/><stop offset="100%" stop-color="#93c687"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g110" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bee498"/><stop offset="40%" stop-color="#ade87e"/><stop offset="100%" stop-color="#65ae53"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g111" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cdeab0"/><stop offset="40%" stop-color="#c0ed9c"/><stop offset="100%" stop-color="#89c17b"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g113" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c7e8a7"/><stop offset="40%" stop-color="#b9eb91"/><stop offset="100%" stop-color="#7cba6c"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g114" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#ddf1c9"/><stop offset="40%" stop-color="#d4f3bc"/><stop offset="100%" stop-color="#afd5a6"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g115" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#ceebb2"/><stop offset="40%" stop-color="#c2ee9f"/><stop offset="100%" stop-color="#8cc27e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g116" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#ffffff"/><stop offset="40%" stop-color="#ffffff"/><stop offset="100%" stop-color="#af9398"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g117" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f1af5d"/><stop offset="40%" stop-color="#ff9832"/><stop offset="100%" stop-color="#a24e32"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g127" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bebebe"/><stop offset="40%" stop-color="#b4b4b4"/><stop offset="100%" stop-color="#7c6469"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g128" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c6c6c6"/><stop offset="40%" stop-color="#bcbcbc"/><stop offset="100%" stop-color="#8b757a"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g129" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cecece"/><stop offset="40%" stop-color="#c7c7c7"/><stop offset="100%" stop-color="#9d8b8f"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g130" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bbbbbb"/><stop offset="40%" stop-color="#b0b0b0"/><stop offset="100%" stop-color="#765c62"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g131" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bebebe"/><stop offset="40%" stop-color="#b4b4b4"/><stop offset="100%" stop-color="#7c6469"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g132" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cecece"/><stop offset="40%" stop-color="#c6c6c6"/><stop offset="100%" stop-color="#9c898d"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g133" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c0c0c0"/><stop offset="40%" stop-color="#b5b5b5"/><stop offset="100%" stop-color="#7f676c"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g134" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d7d7d7"/><stop offset="40%" stop-color="#d1d1d1"/><stop offset="100%" stop-color="#af9fa3"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g135" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cfcfcf"/><stop offset="40%" stop-color="#c8c8c8"/><stop offset="100%" stop-color="#9f8d91"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g136" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b9b9b9"/><stop offset="40%" stop-color="#adadad"/><stop offset="100%" stop-color="#71565c"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g138" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#bbbbbb"/><stop offset="40%" stop-color="#b0b0b0"/><stop offset="100%" stop-color="#765c62"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g140" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#cfcfcf"/><stop offset="40%" stop-color="#c7c7c7"/><stop offset="100%" stop-color="#9e8c90"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g142" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c1c1c1"/><stop offset="40%" stop-color="#b6b6b6"/><stop offset="100%" stop-color="#81696e"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g144" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#e2e2e2"/><stop offset="40%" stop-color="#dedede"/><stop offset="100%" stop-color="#c5babd"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g146" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d9d9d9"/><stop offset="40%" stop-color="#d3d3d3"/><stop offset="100%" stop-color="#b3a5a8"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g148" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b9b9b9"/><stop offset="40%" stop-color="#adadad"/><stop offset="100%" stop-color="#71565c"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g151" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#c8c8c8"/><stop offset="40%" stop-color="#bfbfbf"/><stop offset="100%" stop-color="#8f7a7f"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g154" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#e2e2e2"/><stop offset="40%" stop-color="#dfdfdf"/><stop offset="100%" stop-color="#c8bec0"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g157" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#ef5544"/><stop offset="40%" stop-color="#ff1212"/><stop offset="100%" stop-color="#950521"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g158" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#f37d70"/><stop offset="40%" stop-color="#ff4a4a"/><stop offset="100%" stop-color="#ae4056"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g159" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#facbc5"/><stop offset="40%" stop-color="#ffb6b6"/><stop offset="100%" stop-color="#deb2bb"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g160" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#b6b6b6"/><stop offset="40%" stop-color="#aaaaaa"/><stop offset="100%" stop-color="#6b5056"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g161" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#d1d1d1"/><stop offset="40%" stop-color="#cacaca"/><stop offset="100%" stop-color="#a29195"/></radialGradient>
+    <radialGradient id="x46ef593835c04479ae1d65298e1f3982g162" cx=".5" cy=".5" fx=".33" fy=".33" r=".66"><stop offset="0%" stop-color="#e2e2e2"/><stop offset="40%" stop-color="#e2e2e2"/><stop offset="100%" stop-color="#d2cacc"/></radialGradient>
+  </defs>
+  <circle cx="478.1" cy="193.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g162)" stroke="#b2b2b2" stroke-width="2.8"/>
+  <line x1="490.0" y1="200.4" x2="519.9" y2="218.4" stroke="#b2b2b2" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="530.7" cy="224.9" r="14.1" fill="url(#x46ef593835c04479ae1d65298e1f3982g159)" stroke="#b2b2b2" stroke-width="2.8"/>
+  <line x1="532.3" y1="231.3" x2="536.4" y2="247.3" stroke="#a9a9a9" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="538.2" cy="254.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g154)" stroke="#a1a1a1" stroke-width="2.8"/>
+  <line x1="552.5" y1="257.8" x2="581.3" y2="274.3" stroke="#9e9e9e" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="548.3" y1="265.0" x2="577.2" y2="281.5" stroke="#9e9e9e" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="528.9" y1="258.9" x2="506.5" y2="259.7" stroke="#8f8f8f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="528.5" y1="250.6" x2="506.2" y2="251.5" stroke="#8f8f8f" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="221.4" cy="165.8" r="13.4" fill="url(#x46ef593835c04479ae1d65298e1f3982g114)" stroke="#9e9e9e" stroke-width="2.8"/>
+  <line x1="221.6" y1="169.7" x2="222.3" y2="180.1" stroke="#888888" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="591.4" cy="284.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g144)" stroke="#9c9c9c" stroke-width="2.8"/>
+  <line x1="598.0" y1="290.8" x2="604.2" y2="307.8" stroke="#888888" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="590.2" y1="293.7" x2="596.4" y2="310.6" stroke="#888888" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="473.1" cy="608.0" r="14.1" fill="url(#x46ef593835c04479ae1d65298e1f3982g34)" stroke="#979797" stroke-width="2.8"/>
+  <line x1="470.1" y1="597.2" x2="473.1" y2="567.9" stroke="#898989" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="478.3" y1="598.0" x2="481.4" y2="568.7" stroke="#898989" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="510.5" cy="505.7" r="14.1" fill="url(#x46ef593835c04479ae1d65298e1f3982g35)" stroke="#8d8d8d" stroke-width="2.8"/>
+  <line x1="507.6" y1="517.9" x2="489.7" y2="546.0" stroke="#848484" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="500.6" y1="513.4" x2="482.7" y2="541.6" stroke="#848484" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="496.9" cy="256.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g146)" stroke="#7d7d7d" stroke-width="2.8"/>
+  <line x1="503.5" y1="261.9" x2="510.0" y2="279.1" stroke="#6b6b6b" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="495.7" y1="264.8" x2="502.2" y2="282.0" stroke="#6b6b6b" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="387.9" cy="38.5" r="13.4" fill="url(#x46ef593835c04479ae1d65298e1f3982g109)" stroke="#7c7c7c" stroke-width="2.8"/>
+  <line x1="392.7" y1="46.0" x2="405.5" y2="66.3" stroke="#6e6e6e" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="160.4" cy="420.8" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g50)" stroke="#7c7c7c" stroke-width="2.8"/>
+  <line x1="154.2" y1="434.1" x2="132.5" y2="458.9" stroke="#7b7b7b" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="148.0" y1="428.7" x2="126.2" y2="453.4" stroke="#7b7b7b" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="163.8" y1="412.9" x2="177.5" y2="402.3" stroke="#6a6a6a" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="168.8" y1="419.5" x2="182.6" y2="408.8" stroke="#6a6a6a" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="478.5" cy="555.8" r="16.9" fill="url(#x46ef593835c04479ae1d65298e1f3982g33)" stroke="#7b7b7b" stroke-width="2.8"/>
+  <line x1="464.5" y1="550.9" x2="423.3" y2="536.5" stroke="#767676" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="484.7" y1="559.8" x2="504.0" y2="572.2" stroke="#656565" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="120.0" cy="466.8" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g54)" stroke="#7b7b7b" stroke-width="2.8"/>
+  <line x1="120.6" y1="474.8" x2="113.2" y2="488.9" stroke="#696969" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="113.2" y1="471.0" x2="105.8" y2="485.1" stroke="#696969" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="603.0" cy="316.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g134)" stroke="#757575" stroke-width="2.8"/>
+  <line x1="593.7" y1="321.2" x2="571.2" y2="322.5" stroke="#666666" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="593.3" y1="313.0" x2="570.7" y2="314.2" stroke="#666666" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="222.6" cy="184.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g102)" stroke="#737373" stroke-width="2.8"/>
+  <line x1="217.8" y1="198.0" x2="206.8" y2="228.3" stroke="#737373" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="235.5" y1="183.7" x2="270.0" y2="181.0" stroke="#6a6a6a" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="213.2" y1="176.9" x2="191.7" y2="158.9" stroke="#696969" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="202.7" cy="239.6" r="13.4" fill="url(#x46ef593835c04479ae1d65298e1f3982g115)" stroke="#737373" stroke-width="2.8"/>
+  <circle cx="411.0" cy="532.2" r="14.8" fill="url(#x46ef593835c04479ae1d65298e1f3982g31)" stroke="#707070" stroke-width="2.8"/>
+  <line x1="403.2" y1="520.7" x2="393.0" y2="486.9" stroke="#6f6f6f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="411.1" y1="518.3" x2="400.9" y2="484.5" stroke="#6f6f6f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="402.8" y1="543.4" x2="375.3" y2="563.5" stroke="#6f6f6f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="397.9" y1="536.7" x2="370.4" y2="556.8" stroke="#6f6f6f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="462.8" cy="92.9" r="13.4" fill="url(#x46ef593835c04479ae1d65298e1f3982g111)" stroke="#6f6f6f" stroke-width="2.8"/>
+  <line x1="452.2" y1="89.2" x2="423.5" y2="79.4" stroke="#686868" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="392.9" cy="472.2" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g13)" stroke="#6e6e6e" stroke-width="2.8"/>
+  <line x1="378.8" y1="476.4" x2="345.9" y2="476.4" stroke="#6c6c6c" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="378.8" y1="468.1" x2="345.9" y2="468.1" stroke="#6c6c6c" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="401.0" y1="461.3" x2="419.9" y2="436.0" stroke="#696969" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="361.4" cy="568.5" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g16)" stroke="#6e6e6e" stroke-width="2.8"/>
+  <line x1="364.4" y1="582.9" x2="361.7" y2="615.7" stroke="#6e6e6e" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="356.2" y1="582.2" x2="353.5" y2="615.0" stroke="#6e6e6e" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="347.6" y1="563.4" x2="320.6" y2="543.4" stroke="#6c6c6c" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="352.6" y1="556.7" x2="325.5" y2="536.7" stroke="#6c6c6c" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="356.5" cy="629.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g17)" stroke="#6e6e6e" stroke-width="2.8"/>
+  <line x1="345.1" y1="638.7" x2="314.9" y2="651.4" stroke="#6c6c6c" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="341.9" y1="631.1" x2="311.7" y2="643.8" stroke="#6c6c6c" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="311.7" cy="531.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g15)" stroke="#6b6b6b" stroke-width="2.8"/>
+  <line x1="312.3" y1="517.0" x2="323.4" y2="484.2" stroke="#6a6a6a" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="320.2" y1="519.6" x2="331.3" y2="486.9" stroke="#6a6a6a" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="300.6" y1="541.2" x2="270.3" y2="554.6" stroke="#696969" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="297.2" y1="533.6" x2="267.0" y2="547.0" stroke="#696969" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="300.3" cy="653.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g18)" stroke="#6a6a6a" stroke-width="2.8"/>
+  <line x1="286.5" y1="648.2" x2="259.5" y2="628.8" stroke="#696969" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="291.3" y1="641.4" x2="264.4" y2="622.0" stroke="#696969" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="331.9" cy="472.2" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g14)" stroke="#6a6a6a" stroke-width="2.8"/>
+  <circle cx="317.0" cy="130.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g101)" stroke="#6a6a6a" stroke-width="2.8"/>
+  <line x1="312.5" y1="144.4" x2="294.2" y2="170.9" stroke="#666666" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="305.7" y1="139.6" x2="287.4" y2="166.2" stroke="#666666" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="329.4" y1="125.5" x2="358.8" y2="123.3" stroke="#616161" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="330.0" y1="133.8" x2="359.4" y2="131.5" stroke="#616161" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="255.8" cy="556.5" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g20)" stroke="#676767" stroke-width="2.8"/>
+  <line x1="258.7" y1="570.9" x2="255.9" y2="603.5" stroke="#676767" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="250.4" y1="570.2" x2="247.6" y2="602.8" stroke="#676767" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="250.5" cy="617.2" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g19)" stroke="#676767" stroke-width="2.8"/>
+  <circle cx="428.1" cy="425.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g12)" stroke="#646464" stroke-width="2.8"/>
+  <circle cx="282.9" cy="179.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g95)" stroke="#616161" stroke-width="2.8"/>
+  <line x1="291.4" y1="188.4" x2="302.1" y2="211.7" stroke="#565656" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="283.8" y1="191.8" x2="294.5" y2="215.2" stroke="#565656" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="411.1" cy="75.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g100)" stroke="#616161" stroke-width="2.8"/>
+  <line x1="402.7" y1="86.1" x2="380.2" y2="115.4" stroke="#5d5d5d" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="414.0" y1="67.7" x2="420.5" y2="50.6" stroke="#525252" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="699.0" cy="613.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g161)" stroke="#606060" stroke-width="2.8"/>
+  <line x1="699.1" y1="606.5" x2="699.6" y2="588.8" stroke="#505050" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="183.8" cy="152.2" r="13.4" fill="url(#x46ef593835c04479ae1d65298e1f3982g113)" stroke="#5f5f5f" stroke-width="2.8"/>
+  <circle cx="508.9" cy="287.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g135)" stroke="#5a5a5a" stroke-width="2.8"/>
+  <line x1="523.1" y1="291.5" x2="551.4" y2="308.2" stroke="#585858" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="518.9" y1="298.6" x2="547.2" y2="315.3" stroke="#585858" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="638.8" cy="506.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g140)" stroke="#595959" stroke-width="2.8"/>
+  <line x1="628.9" y1="496.2" x2="614.4" y2="467.1" stroke="#575757" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="636.3" y1="492.6" x2="621.8" y2="463.4" stroke="#575757" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="648.9" y1="509.0" x2="667.1" y2="521.7" stroke="#4c4c4c" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="644.2" y1="515.8" x2="662.4" y2="528.5" stroke="#4c4c4c" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="371.8" cy="126.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g93)" stroke="#595959" stroke-width="2.8"/>
+  <line x1="380.4" y1="134.6" x2="391.9" y2="157.9" stroke="#4e4e4e" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="373.0" y1="138.2" x2="384.4" y2="161.5" stroke="#4e4e4e" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="185.9" cy="401.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g48)" stroke="#585858" stroke-width="2.8"/>
+  <line x1="186.2" y1="408.8" x2="178.4" y2="422.6" stroke="#494949" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="179.0" y1="404.7" x2="171.2" y2="418.4" stroke="#494949" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="106.3" cy="493.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g52)" stroke="#575757" stroke-width="2.8"/>
+  <line x1="109.7" y1="485.2" x2="123.6" y2="474.5" stroke="#484848" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="114.8" y1="491.8" x2="128.7" y2="481.1" stroke="#484848" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="561.4" cy="318.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g129)" stroke="#575757" stroke-width="2.8"/>
+  <line x1="564.4" y1="325.3" x2="574.9" y2="347.4" stroke="#444444" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="611.9" cy="452.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g132)" stroke="#545454" stroke-width="2.8"/>
+  <line x1="609.3" y1="444.6" x2="612.9" y2="427.5" stroke="#464646" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="617.5" y1="446.3" x2="621.0" y2="429.2" stroke="#464646" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="509.7" cy="575.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g69)" stroke="#4e4e4e" stroke-width="2.8"/>
+  <line x1="520.2" y1="586.2" x2="536.3" y2="614.7" stroke="#4d4d4d" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="513.0" y1="590.2" x2="529.1" y2="618.8" stroke="#4d4d4d" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="505.5" y1="566.8" x2="505.3" y2="545.5" stroke="#424242" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="513.8" y1="566.7" x2="513.6" y2="545.4" stroke="#424242" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="539.6" cy="629.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g71)" stroke="#4d4d4d" stroke-width="2.8"/>
+  <line x1="548.4" y1="628.3" x2="565.1" y2="635.4" stroke="#3f3f3f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="545.2" y1="635.9" x2="561.9" y2="643.0" stroke="#3f3f3f" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="303.0" cy="223.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g90)" stroke="#4b4b4b" stroke-width="2.8"/>
+  <line x1="315.3" y1="218.3" x2="345.4" y2="215.7" stroke="#434343" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="316.1" y1="226.6" x2="346.1" y2="224.0" stroke="#434343" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="423.0" cy="44.3" r="13.4" fill="url(#x46ef593835c04479ae1d65298e1f3982g110)" stroke="#444444" stroke-width="2.8"/>
+  <circle cx="393.1" cy="169.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g89)" stroke="#434343" stroke-width="2.8"/>
+  <line x1="388.5" y1="183.4" x2="369.8" y2="209.8" stroke="#3f3f3f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="381.7" y1="178.6" x2="363.1" y2="205.0" stroke="#3f3f3f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="699.7" cy="582.5" r="14.1" fill="url(#x46ef593835c04479ae1d65298e1f3982g158)" stroke="#404040" stroke-width="2.8"/>
+  <line x1="693.8" y1="571.3" x2="679.0" y2="543.0" stroke="#3f3f3f" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="672.5" cy="530.5" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g151)" stroke="#3f3f3f" stroke-width="2.8"/>
+  <line x1="669.8" y1="522.6" x2="673.2" y2="505.7" stroke="#323232" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="678.0" y1="524.2" x2="681.3" y2="507.3" stroke="#323232" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="358.5" cy="218.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g86)" stroke="#3c3c3c" stroke-width="2.8"/>
+  <line x1="362.7" y1="229.8" x2="372.7" y2="256.2" stroke="#343434" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="309.9" cy="357.9" r="14.1" fill="url(#x46ef593835c04479ae1d65298e1f3982g0)" stroke="#3b3b3b" stroke-width="2.8"/>
+  <line x1="317.8" y1="348.6" x2="350.2" y2="310.5" stroke="#363636" stroke-width="6.9" stroke-linecap="round" stroke-dasharray="0.6,13.8"/>
+  <line x1="314.3" y1="369.0" x2="314.7" y2="393.6" stroke="#353535" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="306.0" y1="369.2" x2="306.4" y2="393.8" stroke="#353535" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="319.8" y1="357.8" x2="394.3" y2="356.9" stroke="#2b2b2b" stroke-width="6.9" stroke-linecap="round" stroke-dasharray="0.6,13.8"/>
+  <circle cx="171.5" cy="426.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g47)" stroke="#3a3a3a" stroke-width="2.8"/>
+  <line x1="165.6" y1="439.8" x2="144.3" y2="465.1" stroke="#3a3a3a" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="159.2" y1="434.5" x2="138.0" y2="459.7" stroke="#3a3a3a" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="178.4" y1="421.9" x2="197.6" y2="409.8" stroke="#2e2e2e" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="132.1" cy="473.2" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g49)" stroke="#3a3a3a" stroke-width="2.8"/>
+  <circle cx="618.5" cy="421.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g128)" stroke="#383838" stroke-width="2.8"/>
+  <line x1="611.3" y1="409.2" x2="586.3" y2="368.0" stroke="#353535" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="628.5" y1="423.4" x2="646.6" y2="436.6" stroke="#2d2d2d" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="623.6" y1="430.0" x2="641.7" y2="443.3" stroke="#2d2d2d" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="509.4" cy="536.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g70)" stroke="#353535" stroke-width="2.8"/>
+  <line x1="518.3" y1="535.9" x2="535.0" y2="543.6" stroke="#2b2b2b" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="514.8" y1="543.4" x2="531.5" y2="551.1" stroke="#2b2b2b" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="570.7" cy="642.2" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g74)" stroke="#323232" stroke-width="2.8"/>
+  <line x1="566.9" y1="633.1" x2="567.7" y2="612.0" stroke="#282828" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="575.2" y1="633.4" x2="575.9" y2="612.3" stroke="#282828" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="354.8" cy="305.0" r="8.3" fill="url(#x46ef593835c04479ae1d65298e1f3982g83)" stroke="#323232" stroke-width="2.8"/>
+  <line x1="358.4" y1="298.8" x2="370.3" y2="277.8" stroke="#2f2f2f" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="578.2" cy="354.6" r="17.6" fill="url(#x46ef593835c04479ae1d65298e1f3982g117)" stroke="#323232" stroke-width="2.8"/>
+  <line x1="564.8" y1="360.6" x2="526.4" y2="365.9" stroke="#2b2b2b" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="563.6" y1="352.4" x2="525.2" y2="357.7" stroke="#2b2b2b" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="586.8" y1="345.0" x2="613.1" y2="315.6" stroke="#282828" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="413.1" cy="428.4" r="14.1" fill="url(#x46ef593835c04479ae1d65298e1f3982g11)" stroke="#313131" stroke-width="2.8"/>
+  <line x1="423.3" y1="420.8" x2="475.3" y2="381.9" stroke="#303030" stroke-width="6.9" stroke-linecap="round" stroke-dasharray="0.6,13.8"/>
+  <line x1="402.6" y1="436.1" x2="375.0" y2="445.0" stroke="#2f2f2f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="400.0" y1="428.2" x2="372.5" y2="437.1" stroke="#2f2f2f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="411.3" y1="418.4" x2="401.1" y2="362.8" stroke="#272727" stroke-width="6.9" stroke-linecap="round" stroke-dasharray="0.6,13.8"/>
+  <circle cx="481.2" cy="377.5" r="8.3" fill="url(#x46ef593835c04479ae1d65298e1f3982g116)" stroke="#2f2f2f" stroke-width="2.8"/>
+  <line x1="486.6" y1="375.1" x2="504.3" y2="367.6" stroke="#2a2a2a" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="310.8" cy="406.2" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g1)" stroke="#2f2f2f" stroke-width="2.8"/>
+  <line x1="324.4" y1="411.6" x2="352.1" y2="433.3" stroke="#2d2d2d" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="319.3" y1="418.1" x2="346.9" y2="439.9" stroke="#2d2d2d" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="301.8" y1="415.8" x2="275.6" y2="430.0" stroke="#292929" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="297.8" y1="408.5" x2="271.6" y2="422.8" stroke="#292929" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="360.6" cy="445.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g10)" stroke="#2c2c2c" stroke-width="2.8"/>
+  <line x1="359.4" y1="459.0" x2="347.0" y2="489.1" stroke="#272727" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="351.7" y1="455.8" x2="339.3" y2="485.9" stroke="#272727" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="376.6" cy="266.7" r="14.8" fill="url(#x46ef593835c04479ae1d65298e1f3982g84)" stroke="#2c2c2c" stroke-width="2.8"/>
+  <line x1="383.9" y1="267.3" x2="401.4" y2="268.7" stroke="#232323" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="166.3" cy="301.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g60)" stroke="#2a2a2a" stroke-width="2.8"/>
+  <line x1="162.3" y1="287.7" x2="162.6" y2="255.0" stroke="#282828" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="170.6" y1="287.8" x2="170.9" y2="255.1" stroke="#282828" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="178.8" y1="306.9" x2="201.6" y2="326.3" stroke="#252525" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="173.4" y1="313.2" x2="196.2" y2="332.6" stroke="#252525" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="678.7" cy="499.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g142)" stroke="#262626" stroke-width="2.8"/>
+  <line x1="668.7" y1="488.7" x2="654.4" y2="459.9" stroke="#252525" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="676.1" y1="485.0" x2="661.8" y2="456.2" stroke="#252525" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="166.9" cy="241.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g63)" stroke="#262626" stroke-width="2.8"/>
+  <line x1="174.8" y1="231.7" x2="197.8" y2="218.2" stroke="#1f1f1f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="179.0" y1="238.9" x2="202.0" y2="225.4" stroke="#1f1f1f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="514.0" cy="363.5" r="14.8" fill="url(#x46ef593835c04479ae1d65298e1f3982g103)" stroke="#242424" stroke-width="2.8"/>
+  <line x1="512.0" y1="367.6" x2="506.4" y2="378.9" stroke="#1a1a1a" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="651.8" cy="445.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g133)" stroke="#232323" stroke-width="2.8"/>
+  <circle cx="263.2" cy="432.0" r="14.8" fill="url(#x46ef593835c04479ae1d65298e1f3982g2)" stroke="#232323" stroke-width="2.8"/>
+  <line x1="251.2" y1="426.6" x2="217.3" y2="411.2" stroke="#222222" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="270.4" y1="443.6" x2="278.6" y2="476.2" stroke="#202020" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="262.4" y1="445.6" x2="270.6" y2="478.2" stroke="#202020" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="338.2" cy="499.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g9)" stroke="#232323" stroke-width="2.8"/>
+  <line x1="347.8" y1="510.5" x2="361.5" y2="540.1" stroke="#212121" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="340.3" y1="514.0" x2="353.9" y2="543.5" stroke="#212121" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="323.9" y1="501.7" x2="291.0" y2="496.7" stroke="#202020" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="325.1" y1="493.5" x2="292.2" y2="488.5" stroke="#202020" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="204.5" cy="405.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g3)" stroke="#212121" stroke-width="2.8"/>
+  <line x1="205.3" y1="391.4" x2="207.8" y2="351.9" stroke="#202020" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="198.2" y1="408.6" x2="180.7" y2="417.3" stroke="#181818" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="540.4" cy="550.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g72)" stroke="#202020" stroke-width="2.8"/>
+  <line x1="551.2" y1="560.6" x2="568.4" y2="588.9" stroke="#1f1f1f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="544.1" y1="564.9" x2="561.3" y2="593.2" stroke="#1f1f1f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="208.7" cy="337.8" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g58)" stroke="#202020" stroke-width="2.8"/>
+  <line x1="216.3" y1="328.4" x2="239.2" y2="314.5" stroke="#191919" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="220.6" y1="335.5" x2="243.5" y2="321.6" stroke="#191919" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="363.5" cy="554.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g8)" stroke="#1f1f1f" stroke-width="2.8"/>
+  <line x1="358.9" y1="567.4" x2="340.2" y2="591.9" stroke="#1b1b1b" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="352.3" y1="562.4" x2="333.6" y2="586.9" stroke="#1b1b1b" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="620.7" cy="307.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g127)" stroke="#1e1e1e" stroke-width="2.8"/>
+  <line x1="634.9" y1="303.2" x2="668.3" y2="303.8" stroke="#1e1e1e" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="634.8" y1="311.5" x2="668.1" y2="312.1" stroke="#1e1e1e" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="610.5" y1="299.5" x2="594.7" y2="276.2" stroke="#191919" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="617.4" y1="294.8" x2="601.5" y2="271.5" stroke="#191919" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="682.3" cy="308.2" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g131)" stroke="#1e1e1e" stroke-width="2.8"/>
+  <line x1="686.2" y1="296.2" x2="702.8" y2="274.7" stroke="#191919" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="692.8" y1="301.3" x2="709.4" y2="279.7" stroke="#191919" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="572.1" cy="603.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g76)" stroke="#1e1e1e" stroke-width="2.8"/>
+  <line x1="580.0" y1="606.1" x2="600.8" y2="613.9" stroke="#161616" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="278.0" cy="490.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g4)" stroke="#1e1e1e" stroke-width="2.8"/>
+  <line x1="273.3" y1="503.6" x2="254.7" y2="528.0" stroke="#1a1a1a" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="266.7" y1="498.6" x2="248.1" y2="523.0" stroke="#1a1a1a" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="400.0" cy="356.9" r="8.3" fill="url(#x46ef593835c04479ae1d65298e1f3982g92)" stroke="#1c1c1c" stroke-width="2.8"/>
+  <line x1="402.5" y1="351.5" x2="410.6" y2="334.2" stroke="#171717" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="409.1" cy="269.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g85)" stroke="#191919" stroke-width="2.8"/>
+  <line x1="410.5" y1="282.5" x2="413.7" y2="312.3" stroke="#161616" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="410.6" y1="256.2" x2="427.3" y2="220.4" stroke="#141414" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="418.1" y1="259.7" x2="434.8" y2="223.9" stroke="#141414" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="209.9" cy="216.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g65)" stroke="#191919" stroke-width="2.8"/>
+  <line x1="222.3" y1="221.1" x2="245.1" y2="240.5" stroke="#151515" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="217.0" y1="227.4" x2="239.8" y2="246.9" stroke="#151515" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="329.0" cy="599.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g7)" stroke="#171717" stroke-width="2.8"/>
+  <line x1="314.6" y1="601.9" x2="282.6" y2="596.9" stroke="#151515" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="315.9" y1="593.7" x2="283.9" y2="588.7" stroke="#151515" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="243.4" cy="536.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g5)" stroke="#161616" stroke-width="2.8"/>
+  <line x1="253.2" y1="546.8" x2="267.3" y2="576.4" stroke="#151515" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="245.7" y1="550.4" x2="259.8" y2="579.9" stroke="#151515" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="591.3" cy="263.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g130)" stroke="#141414" stroke-width="2.8"/>
+  <line x1="595.2" y1="252.0" x2="611.7" y2="230.2" stroke="#0f0f0f" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="601.8" y1="257.0" x2="618.3" y2="235.2" stroke="#0f0f0f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="269.6" cy="590.7" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g6)" stroke="#141414" stroke-width="2.8"/>
+  <circle cx="713.3" cy="267.8" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g138)" stroke="#131313" stroke-width="2.8"/>
+  <line x1="703.1" y1="260.5" x2="687.0" y2="237.4" stroke="#0f0f0f" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="709.9" y1="255.7" x2="693.8" y2="232.6" stroke="#0f0f0f" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="251.1" cy="312.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g59)" stroke="#131313" stroke-width="2.8"/>
+  <line x1="247.2" y1="298.1" x2="247.8" y2="265.9" stroke="#121212" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="255.5" y1="298.3" x2="256.1" y2="266.0" stroke="#121212" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="415.1" cy="324.7" r="14.8" fill="url(#x46ef593835c04479ae1d65298e1f3982g87)" stroke="#131313" stroke-width="2.8"/>
+  <line x1="424.1" y1="328.8" x2="448.7" y2="340.1" stroke="#0e0e0e" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="252.2" cy="252.0" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g61)" stroke="#111111" stroke-width="2.8"/>
+  <circle cx="504.2" cy="383.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g97)" stroke="#101010" stroke-width="2.8"/>
+  <line x1="494.7" y1="375.2" x2="467.8" y2="352.6" stroke="#0c0c0c" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="436.7" cy="209.9" r="16.9" fill="url(#x46ef593835c04479ae1d65298e1f3982g88)" stroke="#0f0f0f" stroke-width="2.8"/>
+  <circle cx="174.5" cy="420.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g36)" stroke="#0f0f0f" stroke-width="2.8"/>
+  <line x1="160.1" y1="423.2" x2="127.3" y2="420.1" stroke="#0e0e0e" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="160.9" y1="414.9" x2="128.1" y2="411.8" stroke="#0e0e0e" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="183.4" y1="419.1" x2="201.3" y2="425.3" stroke="#090909" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="180.7" y1="427.0" x2="198.5" y2="433.2" stroke="#090909" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="608.7" cy="616.8" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g79)" stroke="#0e0e0e" stroke-width="2.8"/>
+  <circle cx="113.7" cy="414.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g38)" stroke="#0d0d0d" stroke-width="2.8"/>
+  <line x1="108.5" y1="420.4" x2="93.9" y2="424.6" stroke="#080808" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="106.2" y1="412.5" x2="91.6" y2="416.6" stroke="#080808" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="622.2" cy="223.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g136)" stroke="#0b0b0b" stroke-width="2.8"/>
+  <line x1="636.4" y1="219.6" x2="669.6" y2="220.7" stroke="#0b0b0b" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="636.2" y1="227.9" x2="669.4" y2="229.0" stroke="#0b0b0b" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="683.6" cy="225.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g148)" stroke="#0b0b0b" stroke-width="2.8"/>
+  <line x1="691.7" y1="216.4" x2="709.9" y2="196.4" stroke="#080808" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="458.3" cy="344.5" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g91)" stroke="#090909" stroke-width="2.8"/>
+  <line x1="452.2" y1="350.9" x2="435.3" y2="368.8" stroke="#050505" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="717.1" cy="188.4" r="14.1" fill="url(#x46ef593835c04479ae1d65298e1f3982g157)" stroke="#050505" stroke-width="2.8"/>
+  <line x1="711.5" y1="179.3" x2="695.9" y2="154.2" stroke="#030303" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="207.5" cy="431.9" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g37)" stroke="#040404" stroke-width="2.8"/>
+  <line x1="202.4" y1="437.7" x2="187.8" y2="441.8" stroke="#020202" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="200.1" y1="429.7" x2="185.5" y2="433.8" stroke="#020202" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="86.4" cy="422.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g41)" stroke="#030303" stroke-width="2.8"/>
+  <line x1="95.6" y1="421.5" x2="113.4" y2="428.5" stroke="#010101" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <line x1="92.6" y1="429.3" x2="110.4" y2="436.2" stroke="#010101" stroke-width="4.8" stroke-linecap="round"/>
+  <circle cx="389.3" cy="425.5" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g108)" stroke="#030303" stroke-width="2.8"/>
+  <line x1="397.8" y1="414.9" x2="420.9" y2="385.7" stroke="#020202" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="429.3" cy="375.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g99)" stroke="#010101" stroke-width="2.8"/>
+  <line x1="421.6" y1="365.5" x2="400.3" y2="339.2" stroke="#000000" stroke-width="6.9" stroke-linecap="round"/>
+  <line x1="439.4" y1="380.0" x2="467.3" y2="393.5" stroke="#000000" stroke-width="6.9" stroke-linecap="round"/>
+  <circle cx="689.6" cy="144.1" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g160)" stroke="#010101" stroke-width="2.8"/>
+  <circle cx="180.3" cy="439.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g39)" stroke="#000000" stroke-width="2.8"/>
+  <line x1="166.0" y1="442.7" x2="133.4" y2="440.5" stroke="#000000" stroke-width="4.8" stroke-linecap="round"/>
+  <line x1="166.6" y1="434.5" x2="133.9" y2="432.2" stroke="#000000" stroke-width="4.8" stroke-linecap="round" stroke-dasharray="4.8,9.7"/>
+  <circle cx="119.6" cy="435.3" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g43)" stroke="#000000" stroke-width="2.8"/>
+  <circle cx="392.6" cy="329.6" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g107)" stroke="#000000" stroke-width="2.8"/>
+  <circle cx="477.4" cy="398.4" r="15.7" fill="url(#x46ef593835c04479ae1d65298e1f3982g106)" stroke="#000000" stroke-width="2.8"/>
+</svg>

--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -257,7 +257,7 @@ def load(
     mol_frame: int = 0,
     ts_detect: bool = False,
     ts_frame: int = 0,
-    nci_detect: bool = False,
+    nci_detect: bool | str | list[str] = False,
     cell: bool = False,
     quick: bool = False,
     bohr: bool | None = None,
@@ -302,6 +302,9 @@ def load(
         Reference frame index for TS detection in multi-frame files.
     nci_detect:
         Detect non-covalent interactions with xyzgraph after loading.
+        ``True`` selects all interactions; an exact type/group name or list
+        selects only those interactions.  Groups are ``hb``, ``pi``, and
+        ``ion``.
         When used with ``ensemble=True``, NCI detection is run on
         each frame independently.
     cell:
@@ -395,7 +398,7 @@ def load(
         if nci_detect:
             from xyzrender.readers import detect_nci
 
-            graph = detect_nci(graph)
+            graph = detect_nci(graph, nci_detect)
         return Molecule(graph=graph)
 
     import xyzrender.parsers as fmt
@@ -472,7 +475,7 @@ def load(
     if nci_detect:
         from xyzrender.readers import detect_nci
 
-        graph = detect_nci(graph)
+        graph = detect_nci(graph, nci_detect)
 
     return Molecule(graph=graph, cube_data=cube_data, cell_data=cell_data)
 
@@ -800,6 +803,7 @@ def render(
     ghost_opacity: float | None = None,
     unwrap: bool = False,
     # --- Rendering overlays (1-indexed atom numbering) ---
+    detect_nci: bool | str | list[str] = False,
     ts_bonds: list[tuple[int, int]] | None = None,
     nci_bonds: list[tuple[int, int]] | None = None,
     vdw: bool | list[int] | None = None,
@@ -924,6 +928,10 @@ def render(
         Force-show or add bonds as 1-indexed index-pair strings
         (``["4-5"]``).  Overrides ``unbond`` — a bond listed here
         will not be removed even if it matches an unbond rule.
+    detect_nci:
+        Detect geometric non-covalent interactions.  ``True`` selects all
+        xyzgraph NCI types; a type/group name or list selects only those
+        interactions.  Groups are ``hb``, ``pi``, and ``ion``.
     ts_bonds, nci_bonds:
         Manual TS / NCI bond overlays as 1-indexed atom pairs.
     vdw:
@@ -1210,6 +1218,18 @@ def render(
     # across repeated renders.
     rmol = mol.copy()
 
+    detected_conformer_graphs: list[nx.Graph] | None = None
+    if detect_nci:
+        if _is_ensemble:
+            ens = mol.ensemble
+            assert ens is not None
+            detected_conformer_graphs = _detect_ensemble_ncis(rmol.graph, ens.positions, detect_nci)
+            rmol.graph = detected_conformer_graphs[ens.reference_idx]
+        else:
+            from xyzrender.readers import detect_nci as _detect_nci
+
+            rmol.graph = _detect_nci(rmol.graph, detect_nci)
+
     # --- Orientation reference ---
     if ref is not None:
         ref_path = Path(ref)
@@ -1234,7 +1254,7 @@ def render(
             ens.positions,
             conformer_colors=ens.colors,
             conformer_opacities=ens.opacities,
-            conformer_graphs=ens.conformer_graphs,
+            conformer_graphs=detected_conformer_graphs or ens.conformer_graphs,
             z_nudge=True,
         )
         rmol = Molecule(
@@ -1477,7 +1497,7 @@ def render_gif(
     # --- Per-frame bond detection (gif_trj only) ---
     trj_bonds: bool = False,
     # --- NCI detection (gif_ts / gif_trj / gif_rot) ---
-    detect_nci: bool = False,
+    detect_nci: bool | str | list[str] = False,
     # --- Manual TS bonds (1-indexed atom numbering) ---
     ts_bonds: list[tuple[int, int]] | None = None,
     # --- Vector arrows (gif_rot only) ---
@@ -1550,6 +1570,10 @@ def render_gif(
     ts_bonds:
         Manual transition-state bond pairs using 1-indexed atom numbers.
         In *gif_ts* mode, supplying this skips automatic TS identification.
+    detect_nci:
+        Detect geometric non-covalent interactions.  ``True`` selects all
+        xyzgraph NCI types; a type/group name or list selects only those
+        interactions.  Groups are ``hb``, ``pi``, and ``ion``.
     output:
         Output ``.gif`` path.  Defaults to ``<stem>.gif`` beside *molecule*.
     gif_fps:
@@ -1649,10 +1673,24 @@ def render_gif(
         logger.warning("vib_frames has no effect without gif_ts")
 
     # Resolve config
-    _gif_mol = molecule if isinstance(molecule, Molecule) else load(molecule)
+    _dynamic_nci = gif_ts or gif_trj
+    _gif_conformer_graphs: list[nx.Graph] | None = None
+    if isinstance(molecule, Molecule):
+        _gif_mol = molecule.copy() if detect_nci and not _dynamic_nci else molecule
+    else:
+        _gif_mol = load(molecule)
     if only is not None or exclude is not None:
         _gif_mol = _filter_molecule_atoms(_gif_mol, only=only, exclude=exclude)
         molecule = _gif_mol
+    if detect_nci and not _dynamic_nci:
+        if _gif_mol.ensemble is not None:
+            ens = _gif_mol.ensemble
+            _gif_conformer_graphs = _detect_ensemble_ncis(_gif_mol.graph, ens.positions, detect_nci)
+            _gif_mol.graph = _gif_conformer_graphs[ens.reference_idx]
+        else:
+            from xyzrender.readers import detect_nci as _detect_nci
+
+            _gif_mol.graph = _detect_nci(_gif_mol.graph, detect_nci)
     _gif_graph = _gif_mol.graph
     if not isinstance(config, str):
         cfg = copy.copy(config)
@@ -1793,10 +1831,11 @@ def render_gif(
             )
             raise ValueError(msg)
         mol_path = None
-        ref_graph = molecule.graph
+        ref_graph = _gif_graph
     else:
         mol_path = Path(str(molecule))
-        ref_graph = None
+        # Preserve the graph already prepared for static GIF modes.
+        ref_graph = None if gif_ts or gif_trj else _gif_graph
 
     # Resolve output path
     if output is not None:
@@ -1900,16 +1939,16 @@ def render_gif(
                 _apply_and_save_ref(_ref_mol, cfg, _ref_path)
             ref_graph = _ref_mol.graph
 
-        if isinstance(molecule, Molecule) and molecule.ensemble is not None:
+        if _gif_mol.ensemble is not None:
             from xyzrender.ensemble import merge_graphs
 
-            ens = molecule.ensemble
+            ens = _gif_mol.ensemble
             ref_graph = merge_graphs(
                 ref_graph,
                 ens.positions,
                 conformer_colors=ens.colors,
                 conformer_opacities=ens.opacities,
-                conformer_graphs=ens.conformer_graphs,
+                conformer_graphs=_gif_conformer_graphs or ens.conformer_graphs,
                 z_nudge=False,
             )
 
@@ -2048,10 +2087,17 @@ def _resolve_ensemble_colors(
         return sample_palette(DEFAULT_ENSEMBLE_PALETTE, n_conformers)
 
 
-def _detect_ensemble_ncis(reference_graph: nx.Graph, aligned_positions: list[np.ndarray]) -> list[nx.Graph]:
-    """Detect NCIs per conformer while reusing a fixed covalent topology."""
+def _detect_ensemble_ncis(
+    reference_graph: nx.Graph,
+    aligned_positions: list[np.ndarray] | np.ndarray,
+    selection: bool | str | list[str] = True,
+) -> list[nx.Graph]:
+    """Detect selected NCIs per conformer while reusing fixed topology."""
     from xyzgraph.nci import NCIAnalyzer, build_nci_graph
 
+    from xyzrender.nci_filter import resolve_nci_types
+
+    selected_types = resolve_nci_types(selection)
     topology_graph = copy.deepcopy(reference_graph)
     topology_graph.remove_edges_from([(i, j) for i, j, data in topology_graph.edges(data=True) if data.get("NCI")])
     topology_graph.remove_nodes_from(topology_graph.graph.get("nci_centroid", []))
@@ -2061,10 +2107,12 @@ def _detect_ensemble_ncis(reference_graph: nx.Graph, aligned_positions: list[np.
     analyzer = NCIAnalyzer(topology_graph)
     atom_nodes = list(topology_graph.nodes())
     conformer_graphs = []
-    for positions in aligned_positions:
-        for node, position in zip(atom_nodes, positions, strict=True):
+    for frame_positions in aligned_positions:
+        for node, position in zip(atom_nodes, frame_positions, strict=True):
             topology_graph.nodes[node]["position"] = tuple(float(value) for value in position)
-        ncis = analyzer.detect(np.asarray(positions))
+        ncis = analyzer.detect(np.asarray(frame_positions))
+        if selected_types is not None:
+            ncis = [nci for nci in ncis if nci.type in selected_types]
         topology_graph.graph["ncis"] = ncis
         conformer_graphs.append(build_nci_graph(topology_graph, ncis))
 
@@ -2085,7 +2133,7 @@ def _build_ensemble_molecule(
     kekule: bool = False,
     rebuild: bool = False,
     quick: bool = False,
-    nci_detect: bool = False,
+    nci_detect: bool | str | list[str] = False,
     reference_mol: Molecule | None = None,
 ) -> Molecule:
     """Build a :class:`Molecule` representing an ensemble of conformers.
@@ -2097,7 +2145,7 @@ def _build_ensemble_molecule(
     When *rebuild* is ``True``, each frame's graph is built independently
     so that bonding can differ between conformers — analogous to ``--gif-trj``
     but rendered on one image.  NCI detection is run on each rebuilt frame too
-    when *nci_detect* is also ``True``.
+    when *nci_detect* is enabled.
 
     With fixed topology, NCI detection reuses one analyzer but decorates each
     conformer independently so geometry-dependent interactions remain distinct.
@@ -2253,7 +2301,7 @@ def _build_ensemble_molecule(
 
     conformer_graphs: list[nx.Graph] | None = None
     if nci_detect and not rebuild:
-        conformer_graphs = _detect_ensemble_ncis(ref_graph, aligned_positions)
+        conformer_graphs = _detect_ensemble_ncis(ref_graph, aligned_positions, nci_detect)
         ref_graph = conformer_graphs[reference_frame]
 
     elif rebuild:
@@ -2262,7 +2310,11 @@ def _build_ensemble_molecule(
         from xyzrender.readers import detect_nci as _detect_nci
 
         if nci_detect:
-            ref_graph = _detect_ensemble_ncis(ref_graph, [aligned_positions[reference_frame]])[0]
+            ref_graph = _detect_ensemble_ncis(
+                ref_graph,
+                [aligned_positions[reference_frame]],
+                nci_detect,
+            )[0]
 
         conformer_graphs = []
         for fi, frame in enumerate(frames):
@@ -2275,7 +2327,7 @@ def _build_ensemble_molecule(
                 if "bond_order" in d:
                     d["bond_order"] = 1
             if nci_detect:
-                fg = _detect_nci(fg)
+                fg = _detect_nci(fg, nci_detect)
             conformer_graphs.append(fg)
 
     n_conf = len(frames)

--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -75,9 +75,9 @@ class EnsembleFrames:
     opacities:
         Per-conformer opacity override (``None`` = fully opaque).
     conformer_graphs:
-        Optional per-frame graphs for ``rebuild=True`` ensembles (topology
-        can differ per frame).  ``None`` means all frames share the reference
-        topology.
+        Optional per-frame graphs for rebuilt topology or independently
+        detected NCI interactions.  ``None`` means all frames share the
+        reference topology.
     reference_idx:
         Index into *positions* / *colors* / *opacities* that is the reference.
     """
@@ -1905,7 +1905,12 @@ def render_gif(
 
             ens = molecule.ensemble
             ref_graph = merge_graphs(
-                ref_graph, ens.positions, conformer_colors=ens.colors, conformer_opacities=ens.opacities, z_nudge=False
+                ref_graph,
+                ens.positions,
+                conformer_colors=ens.colors,
+                conformer_opacities=ens.opacities,
+                conformer_graphs=ens.conformer_graphs,
+                z_nudge=False,
             )
 
         # Overlay & Bond Rules
@@ -2043,6 +2048,29 @@ def _resolve_ensemble_colors(
         return sample_palette(DEFAULT_ENSEMBLE_PALETTE, n_conformers)
 
 
+def _detect_ensemble_ncis(reference_graph: nx.Graph, aligned_positions: list[np.ndarray]) -> list[nx.Graph]:
+    """Detect NCIs per conformer while reusing a fixed covalent topology."""
+    from xyzgraph.nci import NCIAnalyzer, build_nci_graph
+
+    topology_graph = copy.deepcopy(reference_graph)
+    topology_graph.remove_edges_from([(i, j) for i, j, data in topology_graph.edges(data=True) if data.get("NCI")])
+    topology_graph.remove_nodes_from(topology_graph.graph.get("nci_centroid", []))
+    for key in ("ncis", "nci_centroid", "nci_centroid_sites"):
+        topology_graph.graph.pop(key, None)
+
+    analyzer = NCIAnalyzer(topology_graph)
+    atom_nodes = list(topology_graph.nodes())
+    conformer_graphs = []
+    for positions in aligned_positions:
+        for node, position in zip(atom_nodes, positions, strict=True):
+            topology_graph.nodes[node]["position"] = tuple(float(value) for value in position)
+        ncis = analyzer.detect(np.asarray(positions))
+        topology_graph.graph["ncis"] = ncis
+        conformer_graphs.append(build_nci_graph(topology_graph, ncis))
+
+    return conformer_graphs
+
+
 def _build_ensemble_molecule(
     trajectory: str | os.PathLike,
     *,
@@ -2070,6 +2098,9 @@ def _build_ensemble_molecule(
     so that bonding can differ between conformers — analogous to ``--gif-trj``
     but rendered on one image.  NCI detection is run on each rebuilt frame too
     when *nci_detect* is also ``True``.
+
+    With fixed topology, NCI detection reuses one analyzer but decorates each
+    conformer independently so geometry-dependent interactions remain distinct.
 
     When *reference_mol* is given, its graph (and positions) are used as the
     reference frame instead of loading from *trajectory*.  This lets
@@ -2220,24 +2251,25 @@ def _build_ensemble_molecule(
         # --no-align: keep each frame's raw coordinates; no Kabsch step.
         aligned_positions = [np.array(fr["positions"], dtype=float) for fr in frames]
 
-    # NCI detection and per-frame graph building happen *after* alignment so that
-    # centroid dummy nodes don't interfere with position array sizes.
-    if nci_detect:
+    conformer_graphs: list[nx.Graph] | None = None
+    if nci_detect and not rebuild:
+        conformer_graphs = _detect_ensemble_ncis(ref_graph, aligned_positions)
+        ref_graph = conformer_graphs[reference_frame]
+
+    elif rebuild:
+        from xyzgraph import build_graph
+
         from xyzrender.readers import detect_nci as _detect_nci
 
-        if reference_mol is None:
-            ref_graph = _detect_nci(ref_graph)
-
-    conformer_graphs: list[nx.Graph] | None = None
-    if rebuild:
-        from xyzgraph import build_graph
+        if nci_detect:
+            ref_graph = _detect_ensemble_ncis(ref_graph, [aligned_positions[reference_frame]])[0]
 
         conformer_graphs = []
         for fi, frame in enumerate(frames):
             if fi == reference_frame:
                 conformer_graphs.append(ref_graph)
                 continue
-            atoms = list(zip(frame["symbols"], [tuple(p) for p in frame["positions"]], strict=True))
+            atoms = list(zip(frame["symbols"], [tuple(p) for p in aligned_positions[fi]], strict=True))
             fg = build_graph(atoms, charge=charge, multiplicity=multiplicity, kekule=kekule, quick=quick)
             for _i, _j, d in fg.edges(data=True):
                 if "bond_order" in d:

--- a/src/xyzrender/cli.py
+++ b/src/xyzrender/cli.py
@@ -98,7 +98,7 @@ Orientation:
   --ref [FILE]            Save/load orientation reference
 
 TS / NCI:
-  --ts / --nci            Auto-detect TS bonds / NCI interactions
+  --ts / --nci [TYPES]    Auto-detect TS bonds / NCI interactions (all or selected types)
   --ts-bond / --nci-bond  Manual bond pairs (1-indexed)
 
 GIF Animation:
@@ -621,9 +621,12 @@ def main() -> None:
     )
     ts_g.add_argument(
         "--nci",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        metavar="TYPES",
         dest="nci_detect",
-        help="Auto-detect NCI interactions via xyzgraph",
+        help="Auto-detect NCIs via xyzgraph; optionally select comma-separated exact types or hb/pi/ion groups",
     )
     ts_g.add_argument("--nci-bond", default="", help='Manual NCI bond pair(s), 1-indexed: "1-5,2-8"')
     ts_g.add_argument(
@@ -939,11 +942,24 @@ def main() -> None:
 
     args = p.parse_args()
 
+    # ``--nci`` has an optional selector, so argparse may consume an input
+    # path that follows the bare flag. Preserve the original option ordering.
+    if args.input is None and isinstance(args.nci_detect, str) and Path(args.nci_detect).is_file():
+        args.input = args.nci_detect
+        args.nci_detect = True
+
     from_stdin = not args.input and not sys.stdin.isatty()
     if not args.input and not args.smi and not from_stdin:
         p.error("No input file provided. Pass a file path, --smi, or pipe via stdin.")
     if args.input and not Path(args.input).is_file():
         p.error(f"No such file or directory: {args.input!r}")
+    if args.nci_detect:
+        from xyzrender.nci_filter import resolve_nci_types
+
+        try:
+            resolve_nci_types(args.nci_detect)
+        except ValueError as exc:
+            p.error(str(exc))
 
     from xyzrender import configure_logging
     from xyzrender.api import (
@@ -1138,12 +1154,17 @@ def main() -> None:
             charge=args.charge,
             multiplicity=args.multiplicity,
             kekule=args.kekule,
+            nci_detect=args.nci_detect,
         )
         xyz_path = Path(args.output).with_suffix(".xyz")
         mol.to_xyz(xyz_path, title=args.smi)
         logger.info("3D geometry written to %s", xyz_path)
     elif from_stdin:
         graph = load_stdin(charge=args.charge, multiplicity=args.multiplicity, kekule=args.kekule)
+        if args.nci_detect:
+            from xyzrender.readers import detect_nci
+
+            graph = detect_nci(graph, args.nci_detect)
         mol = Molecule(graph=graph, cube_data=None, cell_data=None, oriented=False)
     elif not args.input:
         p.error("No input file and stdin is a terminal")

--- a/src/xyzrender/ensemble.py
+++ b/src/xyzrender/ensemble.py
@@ -92,7 +92,7 @@ def merge_graphs(
     Parameters
     ----------
     reference_graph:
-        The graph for the reference conformer (frame 0).
+        Graph used for every conformer when *conformer_graphs* is not given.
     aligned_positions:
         One (N, 3) position array per frame (including reference).
     conformer_colors, conformer_opacities:
@@ -113,12 +113,19 @@ def merge_graphs(
         msg = "ensemble.merge_graphs: aligned_positions must contain at least one frame"
         raise ValueError(msg)
 
-    all_nodes = _node_list(reference_graph)
-    # Separate real atoms from NCI centroid dummy nodes (symbol="*").
-    real_nodes = [n for n in all_nodes if reference_graph.nodes[n].get("symbol") != "*"]
-    centroid_nodes = [n for n in all_nodes if reference_graph.nodes[n].get("symbol") == "*"]
-    n_real = len(real_nodes)
     n_frames = len(aligned_positions)
+    if conformer_graphs is not None and len(conformer_graphs) != n_frames:
+        msg = (
+            "ensemble.merge_graphs: conformer_graphs length does not match "
+            f"aligned_positions ({len(conformer_graphs)} != {n_frames})"
+        )
+        raise ValueError(msg)
+
+    first_graph = conformer_graphs[0] if conformer_graphs is not None else reference_graph
+    first_nodes = _node_list(first_graph)
+    first_real_nodes = [n for n in first_nodes if first_graph.nodes[n].get("symbol") != "*"]
+    first_centroid_nodes = [n for n in first_nodes if first_graph.nodes[n].get("symbol") == "*"]
+    n_real = len(first_real_nodes)
 
     if aligned_positions[0].shape[0] != n_real:
         msg = (
@@ -128,27 +135,68 @@ def merge_graphs(
         raise ValueError(msg)
 
     merged = nx.Graph()
-    merged.graph.update(reference_graph.graph)
+    merged.graph.update(first_graph.graph)
+    merged_centroids: list[int] = []
+    merged_centroid_sites: dict[int, tuple[int, ...]] = {}
+
+    def _prepare_centroids(
+        source: nx.Graph,
+        centroid_nodes: list,
+        node_map: dict,
+        real_nodes: list,
+        positions: np.ndarray,
+    ) -> np.ndarray:
+        """Return aligned dummy positions and translate NCI centroid metadata."""
+        real_position_index = {node: idx for idx, node in enumerate(real_nodes)}
+        source_centroids = set(source.graph.get("nci_centroid", []))
+        source_sites = source.graph.get("nci_centroid_sites", {})
+        centroid_positions = []
+        for old_id in centroid_nodes:
+            new_id = node_map[old_id]
+            sites = tuple(source_sites.get(old_id, ()))
+            if sites and all(site in real_position_index for site in sites):
+                site_positions = np.array([positions[real_position_index[site]] for site in sites])
+                centroid_position = site_positions.mean(axis=0)
+            else:
+                centroid_position = np.asarray(source.nodes[old_id]["position"], dtype=float)
+            centroid_positions.append(centroid_position)
+            if old_id in source_centroids:
+                merged_centroids.append(new_id)
+                if sites:
+                    merged_centroid_sites[new_id] = tuple(node_map[site] for site in sites)
+        return np.asarray(centroid_positions, dtype=float).reshape((-1, 3))
 
     # Reference conformer (index 0): keep original node IDs.
-    ref_map = {nid: nid for nid in real_nodes}
-    stamp_structure_nodes(merged, reference_graph, ref_map, aligned_positions[0], molecule_index=0)
-    stamp_structure_edges(merged, reference_graph, ref_map, molecule_index=0)
-
-    # NCI centroid dummy nodes (reference frame only) keep their existing positions.
-    for nid in centroid_nodes:
-        data = dict(reference_graph.nodes[nid])
-        data["molecule_index"] = 0
-        merged.add_node(nid, **data)
+    ref_map = {nid: nid for nid in first_real_nodes}
+    ref_centroid_map = {nid: nid for nid in first_centroid_nodes}
+    ref_all_map = {**ref_map, **ref_centroid_map}
+    ref_positions = np.vstack(
+        (
+            aligned_positions[0],
+            _prepare_centroids(
+                first_graph,
+                first_centroid_nodes,
+                ref_all_map,
+                first_real_nodes,
+                aligned_positions[0],
+            ),
+        )
+    )
+    stamp_structure_nodes(merged, first_graph, ref_all_map, ref_positions, molecule_index=0)
+    stamp_structure_edges(merged, first_graph, ref_all_map, molecule_index=0)
 
     # Additional conformers: copy node/edge attributes, renumbering node IDs.
-    next_id = max(all_nodes) + 1 if all_nodes else 0
+    next_id = max(first_nodes) + 1 if first_nodes else 0
     for conf_idx in range(1, n_frames):
         pos = aligned_positions[conf_idx]
-        if pos.shape[0] != n_real:
+        frame_graph = conformer_graphs[conf_idx] if conformer_graphs is not None else reference_graph
+        frame_nodes = _node_list(frame_graph)
+        frame_real_nodes = [n for n in frame_nodes if frame_graph.nodes[n].get("symbol") != "*"]
+        frame_centroid_nodes = [n for n in frame_nodes if frame_graph.nodes[n].get("symbol") == "*"]
+        if pos.shape[0] != len(frame_real_nodes):
             msg = (
                 "ensemble.merge_graphs: position array length does not match "
-                f"real atom count in reference graph (got {pos.shape[0]}, expected {n_real})"
+                f"real atom count in conformer {conf_idx} (got {pos.shape[0]}, expected {len(frame_real_nodes)})"
             )
             raise ValueError(msg)
 
@@ -160,26 +208,39 @@ def merge_graphs(
             if conformer_opacities is not None and conf_idx < len(conformer_opacities)
             else None
         )
-        frame_graph = conformer_graphs[conf_idx] if conformer_graphs is not None else reference_graph
-
-        id_map = {old: next_id + i for i, old in enumerate(real_nodes)}
+        id_map = {old: next_id + i for i, old in enumerate(frame_real_nodes)}
+        next_id += len(frame_real_nodes)
+        centroid_map = {old: next_id + i for i, old in enumerate(frame_centroid_nodes)}
+        next_id += len(frame_centroid_nodes)
+        all_map = {**id_map, **centroid_map}
         # Slight z-offset so conformers don't z-fight; scaled by index so later
         # frames sit further back than earlier ones.
         z_offset = conf_idx * _Z_NUDGE if z_nudge else 0.0
 
+        all_positions = np.vstack(
+            (
+                pos,
+                _prepare_centroids(frame_graph, frame_centroid_nodes, all_map, frame_real_nodes, pos),
+            )
+        )
         stamp_structure_nodes(
             merged,
-            reference_graph,  # source of node attributes (symbols, etc.) — per-frame positions come from `pos`
-            id_map,
-            pos,
+            frame_graph,
+            all_map,
+            all_positions,
             molecule_index=conf_idx,
             color=color,
             opacity=opacity,
             z_offset=z_offset,
         )
-        stamp_structure_edges(merged, frame_graph, id_map, molecule_index=conf_idx, color=color)
+        stamp_structure_edges(merged, frame_graph, all_map, molecule_index=conf_idx, color=color)
         merge_aromatic_rings(merged, frame_graph, id_map)
 
-        next_id += n_real
+    if merged_centroids:
+        merged.graph["nci_centroid"] = merged_centroids
+        merged.graph["nci_centroid_sites"] = merged_centroid_sites
+    else:
+        merged.graph.pop("nci_centroid", None)
+        merged.graph.pop("nci_centroid_sites", None)
 
     return merged

--- a/src/xyzrender/gif.py
+++ b/src/xyzrender/gif.py
@@ -189,7 +189,7 @@ def render_vibration_gif(
     n_frames: int | None = None,
     bounce_degrees: float | None = None,
     reference_graph: nx.Graph | None = None,
-    detect_nci: bool = False,
+    detect_nci: bool | str | list[str] = False,
     auto_detect_ts: bool | None = None,
 ) -> None:
     """Render a TS vibrational mode as an animated GIF.
@@ -201,14 +201,20 @@ def render_vibration_gif(
 
     If ``reference_graph`` is provided (e.g. from ``-V`` viewer rotation),
     all frames are rotated to match that orientation.
-    If ``detect_nci`` is True, NCI interactions are detected once on the
+    If ``detect_nci`` is enabled, NCI interactions are detected once on the
     TS geometry and applied to every frame (centroids recomputed per frame).
+    A string or list limits detection to the selected NCI types or groups.
     If ``axis`` is provided, the vibration is combined with a rotation
     around that axis (``n_frames`` controls total frames). When
     ``bounce_degrees`` is also set, the rotation oscillates sinusoidally
     between ±``bounce_degrees`` over the full frame range instead of a
     linear 360° sweep.
     """
+    if detect_nci:
+        from xyzrender.nci_filter import resolve_nci_types
+
+        resolve_nci_types(detect_nci)
+
     vib_kwargs = {}
     if vib_frames is not None:
         vib_kwargs["n_frames"] = vib_frames
@@ -258,8 +264,9 @@ def render_vibration_gif(
     if detect_nci:
         from xyzgraph import detect_ncis
 
-        detect_ncis(ts_graph)
-        fixed_ncis = ts_graph.graph.get("ncis", [])
+        from xyzrender.nci_filter import filter_ncis
+
+        fixed_ncis = filter_ncis(detect_ncis(ts_graph), detect_nci)
 
     # Apply viewer rotation to all frames if a reference orientation was given
     if reference_graph is not None:
@@ -516,7 +523,7 @@ def render_trajectory_gif(
     multiplicity: int | None = None,
     fps: int = 10,
     reference_graph: nx.Graph | None = None,
-    detect_nci: bool = False,
+    detect_nci: bool | str | list[str] = False,
     axis: str | None = None,
     kekule: bool = False,
     trj_bonds: bool = False,
@@ -528,11 +535,17 @@ def render_trajectory_gif(
     If ``trj_bonds`` is True, builds a fresh graph for every frame so
     that changing connectivity (e.g. NEB-TS MEPs) is shown correctly.
     If ``reference_graph`` is provided, all frames are rotated to match.
-    If ``detect_nci`` is True, NCI interactions are re-detected per frame
+    If ``detect_nci`` is enabled, NCI interactions are re-detected per frame
     using xyzgraph's NCIAnalyzer (topology built once, geometry per frame).
+    A string or list limits detection to the selected NCI types or groups.
     If ``axis`` is provided, the molecule rotates 360° around that axis
     over the course of the trajectory.
     """
+    if detect_nci:
+        from xyzrender.nci_filter import resolve_nci_types
+
+        resolve_nci_types(detect_nci)
+
     from xyzgraph import build_graph
 
     if trj_bonds:
@@ -601,7 +614,8 @@ def render_trajectory_gif(
         frames,
         config,
         nci_analyzer=nci_analyzer,
-        detect_nci_per_frame=detect_nci and trj_bonds,
+        detect_nci_per_frame=bool(detect_nci and trj_bonds),
+        nci_types=detect_nci,
         rotation_axis=axis_vec,
         rotation_sign=axis_sign,
     )
@@ -888,6 +902,7 @@ def _render_traj_frame(
     nci_analyzer: "NCIAnalyzer | None",
     fixed_ncis: list | None,
     detect_nci_per_frame: bool,
+    nci_types: bool | str | list[str] | None,
     rotation_axis: np.ndarray | None,
     rotation_sign: float,
     angles: np.ndarray | None,
@@ -918,9 +933,17 @@ def _render_traj_frame(
         from xyzgraph.nci import NCIAnalyzer
 
         ncis = NCIAnalyzer(graph).detect(np.array(positions))
+        if nci_types is not None:
+            from xyzrender.nci_filter import filter_ncis
+
+            ncis = filter_ncis(ncis, nci_types)
         render_graph = build_nci_graph(graph, ncis)
     elif nci_analyzer is not None:
         ncis = nci_analyzer.detect(np.array(positions))
+        if nci_types is not None:
+            from xyzrender.nci_filter import filter_ncis
+
+            ncis = filter_ncis(ncis, nci_types)
         render_graph = build_nci_graph(graph, ncis)
     elif fixed_ncis is not None:
         render_graph = build_nci_graph(graph, fixed_ncis)
@@ -953,6 +976,7 @@ def _render_frames(
     nci_analyzer: NCIAnalyzer | None = None,
     fixed_ncis: list | None = None,
     detect_nci_per_frame: bool = False,
+    nci_types: bool | str | list[str] | None = None,
     rotation_axis: np.ndarray | None = None,
     rotation_sign: float = 1.0,
     rotation_degrees: float = 360.0,
@@ -966,6 +990,8 @@ def _render_frames(
     (centroids recomputed from current atom positions each frame).
     If *detect_nci_per_frame* is True, a fresh ``NCIAnalyzer`` is built
     inside each worker from ``frame["graph"]`` (trj_bonds + detect_nci).
+    *nci_types* optionally filters the per-frame detections before graph
+    decoration.
     If *rotation_axis* is provided, each frame is incrementally rotated
     around that axis over *rotation_degrees* (default 360°), or, when
     *bounce_degrees* is set, oscillates sinusoidally between ±bounce_degrees
@@ -999,6 +1025,7 @@ def _render_frames(
         nci_analyzer=nci_analyzer,
         fixed_ncis=fixed_ncis,
         detect_nci_per_frame=detect_nci_per_frame,
+        nci_types=nci_types,
         rotation_axis=rotation_axis,
         rotation_sign=rotation_sign,
         angles=angles,

--- a/src/xyzrender/nci_filter.py
+++ b/src/xyzrender/nci_filter.py
@@ -1,0 +1,57 @@
+"""Selection helpers for xyzgraph non-covalent interaction types."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from xyzgraph.nci import NCI_TYPES
+
+if TYPE_CHECKING:
+    from xyzgraph.nci import NCIData
+
+
+NCI_GROUPS: dict[str, frozenset[str]] = {
+    "hb": frozenset({"hbond", "hbond_bifurcated", "hb_pi"}),
+    "pi": frozenset(nci_type for nci_type in NCI_TYPES if nci_type.startswith("pi_") or nci_type.endswith("_pi")),
+    "ion": frozenset({"cation_pi", "anion_pi", "cation_lp", "ionic", "salt_bridge"}),
+}
+
+
+def resolve_nci_types(selection: bool | str | list[str]) -> frozenset[str] | None:
+    """Resolve exact xyzgraph NCI types and group aliases.
+
+    ``True`` or ``"all"`` selects every type and is represented by ``None``.
+    """
+    if selection is True:
+        return None
+    if selection is False:
+        return frozenset()
+
+    values = [selection] if isinstance(selection, str) else selection
+    names = [part.strip().lower() for value in values for part in value.split(",") if part.strip()]
+    if not names:
+        msg = "NCI type selection cannot be empty"
+        raise ValueError(msg)
+    if "all" in names:
+        return None
+
+    valid_types = set(NCI_TYPES)
+    resolved: set[str] = set()
+    for name in names:
+        if name in NCI_GROUPS:
+            resolved.update(NCI_GROUPS[name])
+        elif name in valid_types:
+            resolved.add(name)
+        else:
+            valid = ", ".join((*NCI_GROUPS, *NCI_TYPES))
+            msg = f"Unknown NCI type or group {name!r}; valid values: {valid}"
+            raise ValueError(msg)
+    return frozenset(resolved)
+
+
+def filter_ncis(ncis: list[NCIData], selection: bool | str | list[str]) -> list[NCIData]:
+    """Return interactions selected by exact type or group alias."""
+    selected = resolve_nci_types(selection)
+    if selected is None:
+        return ncis
+    return [nci for nci in ncis if nci.type in selected]

--- a/src/xyzrender/readers.py
+++ b/src/xyzrender/readers.py
@@ -505,7 +505,7 @@ def load_ts_molecule(
 # ---------------------------------------------------------------------------
 
 
-def detect_nci(graph: nx.Graph) -> nx.Graph:
+def detect_nci(graph: nx.Graph, nci_types: bool | str | list[str] = True) -> nx.Graph:
     """Detect non-covalent interactions and return a decorated graph.
 
     Uses xyzgraph's NCI detection algorithm.  Returns a new graph with
@@ -516,20 +516,33 @@ def detect_nci(graph: nx.Graph) -> nx.Graph:
     ----------
     graph:
         Molecular graph built by xyzgraph (e.g. from :func:`load_molecule`).
+    nci_types:
+        ``True`` selects every detected interaction.  Exact xyzgraph type
+        names and the ``hb``, ``pi``, and ``ion`` groups may be supplied as
+        a string or list.
 
     Returns
     -------
     networkx.Graph
         New graph with NCI edges and centroid nodes added.
     """
-    from xyzgraph import detect_ncis
     from xyzgraph.nci import build_nci_graph
 
     logger.info("Detecting NCI interactions")
-    detect_ncis(graph)
-    nci_graph = build_nci_graph(graph)
-    n_nci = sum(1 for _, _, d in nci_graph.edges(data=True) if d.get("NCI"))
-    logger.info("Detected %d NCI interactions", n_nci)
+    from xyzrender.nci_filter import filter_ncis
+
+    if "ncis" in graph.graph:
+        graph.remove_edges_from([(i, j) for i, j, data in graph.edges(data=True) if data.get("NCI")])
+        graph.remove_nodes_from(graph.graph.get("nci_centroid", []))
+        for key in ("ncis", "nci_centroid", "nci_centroid_sites"):
+            graph.graph.pop(key, None)
+
+    from xyzgraph import detect_ncis
+
+    ncis = filter_ncis(detect_ncis(graph), nci_types)
+    graph.graph["ncis"] = ncis
+    nci_graph = build_nci_graph(graph, ncis)
+    logger.info("Detected %d NCI interactions", len(ncis))
     return nci_graph
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,6 +64,79 @@ def test_load_nci_detect():
     assert mol.graph.number_of_nodes() > 0
 
 
+def test_load_nci_detect_filters_by_group():
+    mol = load(STRUCTURES / "bimp.v000.xyz", nci_detect=["hb"])
+
+    nci_types = {data["nci_type"] for *_edge, data in mol.graph.edges(data=True) if data.get("NCI")}
+    assert nci_types == {"hbond_bifurcated"}
+    assert all(data.get("symbol") != "*" for _, data in mol.graph.nodes(data=True))
+
+
+def test_nci_type_groups_and_exact_names_resolve_distinctly():
+    from xyzrender.nci_filter import resolve_nci_types
+
+    assert resolve_nci_types("hbond") == {"hbond"}
+    assert resolve_nci_types("HB") == {"hbond", "hbond_bifurcated", "hb_pi"}
+    assert resolve_nci_types("pi") == {
+        "anion_pi",
+        "cation_pi",
+        "ch_pi",
+        "halogen_pi",
+        "hb_pi",
+        "pi_pi_domain_domain",
+        "pi_pi_parallel",
+        "pi_pi_ring_domain",
+        "pi_pi_t_shaped",
+    }
+    assert resolve_nci_types("ion") == {"anion_pi", "cation_lp", "cation_pi", "ionic", "salt_bridge"}
+    assert resolve_nci_types("hb, ionic") == {"hbond", "hbond_bifurcated", "hb_pi", "ionic"}
+    assert resolve_nci_types(True) is None
+    assert resolve_nci_types("all") is None
+
+
+def test_nci_type_selection_rejects_unknown_names():
+    from xyzrender.nci_filter import resolve_nci_types
+
+    with pytest.raises(ValueError, match="Unknown NCI type or group 'dispersion'"):
+        resolve_nci_types("dispersion")
+
+
+def test_render_detect_nci_filters_without_mutating_molecule():
+    mol = load(STRUCTURES / "bimp.v000.xyz")
+    original_nodes = mol.graph.number_of_nodes()
+    original_edges = mol.graph.number_of_edges()
+
+    svg = str(render(mol, detect_nci=["hb"], orient=False))
+
+    assert "stroke-dasharray" in svg
+    assert mol.graph.number_of_nodes() == original_nodes
+    assert mol.graph.number_of_edges() == original_edges
+    assert not any(data.get("NCI") for *_edge, data in mol.graph.edges(data=True))
+
+
+def test_render_refilters_previously_detected_ncis():
+    mol = load(STRUCTURES / "bimp.v000.xyz", nci_detect=True)
+    original_nci_types = {data["nci_type"] for *_edge, data in mol.graph.edges(data=True) if data.get("NCI")}
+
+    svg = str(render(mol, detect_nci=["hb"], orient=False))
+
+    assert "stroke-dasharray" in svg
+    assert {data["nci_type"] for *_edge, data in mol.graph.edges(data=True) if data.get("NCI")} == original_nci_types
+
+
+def test_render_can_change_a_previous_nci_selection():
+    from unittest.mock import patch
+
+    mol = load(STRUCTURES / "bimp.v000.xyz", nci_detect=["hb"])
+
+    with patch("xyzrender.renderer.render_svg", return_value="<svg />") as mock_render:
+        render(mol, detect_nci=["pi"], orient=False)
+
+    rendered_graph = mock_render.call_args.args[0]
+    nci_types = {data["nci_type"] for *_edge, data in rendered_graph.edges(data=True) if data.get("NCI")}
+    assert nci_types == {"pi_pi_parallel", "pi_pi_t_shaped"}
+
+
 def test_load_smiles():
     pytest.importorskip("rdkit", reason="rdkit required")
     mol = load("CCO", smiles=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,29 @@ def test_basic_render(tmp_path):
     assert out.read_text().startswith("<?xml") or out.read_text().startswith("<svg")
 
 
+def test_nci_flag_accepts_optional_type_groups(tmp_path):
+    source = _STRUCTURES / "bimp.v000.xyz"
+    all_out = tmp_path / "all.svg"
+    hb_out = tmp_path / "hb.svg"
+
+    all_result = _run_cli(str(source), "--nci", "--no-grad", "--no-orient", "-o", str(all_out))
+    hb_result = _run_cli(str(source), "--nci", "hb", "--no-grad", "--no-orient", "-o", str(hb_out))
+
+    assert all_result.returncode == 0
+    assert hb_result.returncode == 0
+    assert all_out.read_text().count("<circle") > hb_out.read_text().count("<circle")
+
+
+def test_bare_nci_flag_can_precede_input(tmp_path):
+    source = _STRUCTURES / "bimp.v000.xyz"
+    output = tmp_path / "nci.svg"
+
+    result = _run_cli("--nci", str(source), "--no-grad", "--no-orient", "-o", str(output))
+
+    assert result.returncode == 0
+    assert output.exists()
+
+
 @pytest.mark.skipif(not (_STRUCTURES / "caffeine_dens.cube").exists(), reason="fixture not found")
 def test_cub_density_surface(tmp_path):
     src = _STRUCTURES / "caffeine_dens.cube"

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -134,6 +134,64 @@ def test_rebuilt_ensemble_detects_ncis_on_supplied_reference() -> None:
     assert any(data.get("NCI") for *_edge, data in reference_graph.edges(data=True))
 
 
+def test_load_ensemble_filters_detected_nci_types():
+    mol = load(
+        "examples/structures/bimp.v000.xyz",
+        ensemble=True,
+        max_frames=2,
+        nci_detect=["hb"],
+    )
+
+    nci_types = {data["nci_type"] for *_edge, data in mol.graph.edges(data=True) if data.get("NCI")}
+    assert nci_types == {"hbond_bifurcated"}
+    assert mol.ensemble is not None
+    assert mol.ensemble.conformer_graphs is not None
+    for graph in mol.ensemble.conformer_graphs:
+        frame_types = {data["nci_type"] for *_edge, data in graph.edges(data=True) if data.get("NCI")}
+        assert frame_types <= {"hbond", "hbond_bifurcated", "hb_pi"}
+
+
+def test_render_ensemble_filters_ncis_per_conformer_without_mutation():
+    from unittest.mock import patch
+
+    mol = load("examples/structures/bimp.v000.xyz", ensemble=True, max_frames=2)
+
+    with patch("xyzrender.renderer.render_svg", return_value="<svg />") as mock_render:
+        render(mol, detect_nci=["hb"], orient=False)
+
+    rendered_graph = mock_render.call_args.args[0]
+    nci_types = {data["nci_type"] for *_edge, data in rendered_graph.edges(data=True) if data.get("NCI")}
+    assert nci_types <= {"hbond", "hbond_bifurcated", "hb_pi"}
+    assert nci_types
+    assert any(
+        data.get("molecule_index") == 1 and data.get("nci_type") == "hbond"
+        for *_edge, data in rendered_graph.edges(data=True)
+    )
+    assert mol.ensemble is not None
+    assert mol.ensemble.conformer_graphs is None
+    assert not any(data.get("NCI") for *_edge, data in mol.graph.edges(data=True))
+
+
+def test_render_gif_ensemble_filters_ncis_per_conformer(tmp_path):
+    from unittest.mock import patch
+
+    from xyzrender import render_gif
+
+    mol = load("examples/structures/bimp.v000.xyz", ensemble=True, max_frames=2)
+
+    with patch("xyzrender.gif.render_rotation_gif") as mock_render:
+        render_gif(mol, gif_rot="y", detect_nci=["hb"], output=tmp_path / "ensemble.gif")
+
+    rendered_graph = mock_render.call_args.kwargs["graph"]
+    nci_types = {data["nci_type"] for *_edge, data in rendered_graph.edges(data=True) if data.get("NCI")}
+    assert nci_types <= {"hbond", "hbond_bifurcated", "hb_pi"}
+    assert nci_types
+    assert any(
+        data.get("molecule_index") == 1 and data.get("nci_type") == "hbond"
+        for *_edge, data in rendered_graph.edges(data=True)
+    )
+
+
 def test_ensemble_opacity(tmp_path: Path) -> None:
     xyz_path = _make_traj(tmp_path)
     mol = _build_ensemble_molecule(xyz_path, ensemble_opacity=0.4)

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -70,6 +70,70 @@ def test_build_ensemble_molecule(tmp_path: Path) -> None:
     assert all(c is not None and c.startswith("#") for c in ens.colors)
 
 
+def test_load_ensemble_detects_ncis_for_each_conformer() -> None:
+    mol = load(
+        "examples/structures/bimp.v000.xyz",
+        ensemble=True,
+        max_frames=2,
+        nci_detect=True,
+    )
+    assert mol.ensemble is not None
+    assert mol.ensemble.conformer_graphs is not None
+
+    nci_types = [
+        {data["nci_type"] for *_edge, data in graph.edges(data=True) if data.get("NCI")}
+        for graph in mol.ensemble.conformer_graphs
+    ]
+    assert "hbond" not in nci_types[0]
+    assert "hbond" in nci_types[1]
+
+    merged = merge_graphs(
+        mol.graph,
+        mol.ensemble.positions,
+        conformer_graphs=mol.ensemble.conformer_graphs,
+        z_nudge=False,
+    )
+    assert all(
+        any(data.get("NCI") and data.get("molecule_index") == frame_idx for *_edge, data in merged.edges(data=True))
+        for frame_idx in range(2)
+    )
+
+
+def test_rebuilt_ensemble_nci_centroids_use_aligned_positions() -> None:
+    import numpy as np
+
+    mol = load(
+        "examples/structures/bimp.v000.xyz",
+        ensemble=True,
+        max_frames=2,
+        rebuild=True,
+        nci_detect=True,
+    )
+    assert mol.ensemble is not None
+    assert mol.ensemble.conformer_graphs is not None
+
+    for frame_idx, graph in enumerate(mol.ensemble.conformer_graphs):
+        for centroid, sites in graph.graph.get("nci_centroid_sites", {}).items():
+            expected = mol.ensemble.positions[frame_idx][list(sites)].mean(axis=0)
+            assert np.allclose(graph.nodes[centroid]["position"], expected)
+
+
+def test_rebuilt_ensemble_detects_ncis_on_supplied_reference() -> None:
+    path = "examples/structures/bimp.v000.xyz"
+    mol = load(
+        path,
+        ensemble=True,
+        max_frames=2,
+        rebuild=True,
+        nci_detect=True,
+        reference_mol=load(path),
+    )
+    assert mol.ensemble is not None
+    assert mol.ensemble.conformer_graphs is not None
+    reference_graph = mol.ensemble.conformer_graphs[mol.ensemble.reference_idx]
+    assert any(data.get("NCI") for *_edge, data in reference_graph.edges(data=True))
+
+
 def test_ensemble_opacity(tmp_path: Path) -> None:
     xyz_path = _make_traj(tmp_path)
     mol = _build_ensemble_molecule(xyz_path, ensemble_opacity=0.4)
@@ -170,6 +234,54 @@ def test_merge_graphs_structure(tmp_path: Path) -> None:
     assert all(g.nodes[n].get("structure_color", "").startswith("#") for n in non_ref)
 
 
+def test_merge_graphs_preserves_each_conformers_nci_centroids() -> None:
+    import networkx as nx
+    import numpy as np
+
+    def _frame_graph(nci_type: str, centroid_x: float) -> nx.Graph:
+        graph = nx.Graph()
+        graph.add_node(0, symbol="C", position=(0.0, 0.0, 0.0))
+        graph.add_node(1, symbol="C", position=(2.0, 0.0, 0.0))
+        graph.add_node(2, symbol="*", position=(centroid_x, 0.0, 0.0))
+        graph.add_edge(0, 2, NCI=True, nci_type=nci_type)
+        graph.add_edge(2, 1, NCI=True, nci_type=nci_type)
+        graph.graph["nci_centroid"] = [2]
+        graph.graph["nci_centroid_sites"] = {2: (0, 1)}
+        return graph
+
+    frame_graphs = [_frame_graph("pi_frame_0", 1.0), _frame_graph("pi_frame_1", 2.0)]
+    positions = np.array(
+        [
+            [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            [[1.0, 0.0, 0.0], [3.0, 0.0, 0.0]],
+        ]
+    )
+
+    merged = merge_graphs(
+        frame_graphs[1],
+        positions,
+        conformer_opacities=[None, 0.25],
+        conformer_graphs=frame_graphs,
+        z_nudge=False,
+    )
+
+    for frame_idx, expected_type in enumerate(("pi_frame_0", "pi_frame_1")):
+        centroids = [
+            node
+            for node, data in merged.nodes(data=True)
+            if data.get("molecule_index") == frame_idx and data.get("symbol") == "*"
+        ]
+        assert len(centroids) == 1
+        expected_opacity = None if frame_idx == 0 else 0.25
+        assert merged.nodes[centroids[0]].get("structure_opacity") == expected_opacity
+        nci_types = {
+            data["nci_type"]
+            for *_edge, data in merged.edges(data=True)
+            if data.get("molecule_index") == frame_idx and data.get("NCI")
+        }
+        assert nci_types == {expected_type}
+
+
 def test_merge_graphs_cpk_no_structure_color(tmp_path: Path) -> None:
     """'cpk': merge_graphs sets no structure_color override — renderer falls back to CPK."""
     xyz_path = _make_traj(tmp_path)
@@ -225,6 +337,30 @@ def test_ensemble_render_produces_svg(tmp_path: Path) -> None:
     result = render(mol, output=tmp_path / "out.svg")
     assert isinstance(result, SVGResult)
     assert "<svg" in (tmp_path / "out.svg").read_text()
+
+
+def test_ensemble_rotation_gif_preserves_per_conformer_ncis(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    from xyzrender import render_gif
+
+    mol = load(
+        "examples/structures/bimp.v000.xyz",
+        ensemble=True,
+        max_frames=2,
+        nci_detect=True,
+    )
+
+    with patch("xyzrender.gif.render_rotation_gif") as mock_render:
+        render_gif(mol, gif_rot="y", output=tmp_path / "ensemble.gif")
+
+    rendered_graph = mock_render.call_args.kwargs["graph"]
+    frame_one_types = {
+        data["nci_type"]
+        for *_edge, data in rendered_graph.edges(data=True)
+        if data.get("molecule_index") == 1 and data.get("NCI")
+    }
+    assert "hbond" in frame_one_types
 
 
 def test_ensemble_render_twice_no_mutation(tmp_path: Path) -> None:

--- a/tests/test_gif.py
+++ b/tests/test_gif.py
@@ -161,6 +161,47 @@ def test_render_gif_ts_detection_mode(tmp_path, ts_bonds, auto_detect, expected)
     assert config.ts_bonds == expected
 
 
+def test_render_gif_vibration_filters_detected_nci_types(tmp_path):
+    from unittest.mock import patch
+
+    import networkx as nx
+    from xyzgraph.nci import NCIData
+
+    from xyzrender import render_gif
+
+    frames = [{"symbols": ["C", "C", "C"], "positions": [[0, 0, 0], [1.4, 0, 0], [2.8, 0, 0]]}]
+    ts_graph = nx.Graph()
+    ts_graph.add_nodes_from(
+        (i, {"symbol": "C", "position": tuple(position)}) for i, position in enumerate(frames[0]["positions"])
+    )
+    analysis = {"graph": {"ts_graph": ts_graph}, "trajectory": {"frames": frames}}
+    detected = [
+        NCIData("hbond", (0,), (1,), (), {}, 1.0),
+        NCIData("pi_pi_parallel", (1,), (2,), (), {}, 1.0),
+    ]
+
+    def _detect(graph):
+        graph.graph["ncis"] = detected
+        return detected
+
+    with (
+        patch("graphrc.run_vib_analysis", return_value=analysis),
+        patch("xyzgraph.detect_ncis", side_effect=_detect),
+        patch("xyzrender.gif._render_frames", return_value=[b""]) as mock_render,
+        patch("xyzrender.gif._stitch_gif"),
+    ):
+        render_gif(
+            STRUCTURES / "sn2.out",
+            gif_ts=True,
+            detect_nci=["hb"],
+            orient=False,
+            output=tmp_path / "ts.gif",
+        )
+
+    fixed_ncis = mock_render.call_args.kwargs["fixed_ncis"]
+    assert [nci.type for nci in fixed_ncis] == ["hbond"]
+
+
 @pytest.mark.parametrize("ts_bonds", [[(1, 1)], [(1, 999)]])
 def test_render_gif_ts_rejects_invalid_manual_bonds(tmp_path, ts_bonds):
     from unittest.mock import patch
@@ -214,6 +255,57 @@ def test_render_trajectory_gif_trj_bonds(tmp_path):
     assert len({id(f["graph"]) for f in seen}) == len(seen)
 
 
+def test_render_trajectory_frame_filters_detected_nci_types():
+    from unittest.mock import Mock, patch
+
+    import networkx as nx
+    from xyzgraph.nci import NCIData
+
+    from xyzrender.gif import _render_traj_frame
+    from xyzrender.types import RenderConfig
+
+    graph = nx.Graph()
+    graph.add_nodes_from(
+        [
+            (0, {"symbol": "C", "position": (0.0, 0.0, 0.0)}),
+            (1, {"symbol": "C", "position": (1.4, 0.0, 0.0)}),
+        ]
+    )
+    frame = {"symbols": ["C", "C"], "positions": [[0.0, 0.0, 0.0], [1.4, 0.0, 0.0]]}
+    analyzer = Mock()
+    analyzer.detect.return_value = [
+        NCIData("hbond", (0,), (1,), (), {}, 1.0),
+        NCIData("pi_pi_parallel", (0,), (1,), (), {}, 1.0),
+    ]
+    captured = {}
+
+    def _build(source, ncis):
+        captured["types"] = [nci.type for nci in ncis]
+        return source
+
+    with (
+        patch("xyzgraph.nci.build_nci_graph", side_effect=_build),
+        patch("xyzrender.gif.render_svg", return_value="<svg />"),
+        patch("xyzrender.gif.svg_to_png_bytes", return_value=b"png"),
+    ):
+        _render_traj_frame(
+            (0, frame),
+            graph,
+            RenderConfig(),
+            analyzer,
+            None,
+            False,
+            ["hb"],
+            None,
+            1.0,
+            None,
+            np.full((0, 3), np.nan),
+            np.full((0, 3), np.nan),
+        )
+
+    assert captured["types"] == ["hbond"]
+
+
 # ---------------------------------------------------------------------------
 # render_gif API — rotation GIF via public API
 # ---------------------------------------------------------------------------
@@ -246,6 +338,63 @@ def test_api_render_gif_rotation_true_uses_y_axis(tmp_path):
         render_gif(_tiny_molecule(), gif_rot=True, output=tmp_path / "true.gif")
 
     assert mock_render.call_args.kwargs["axis"] == "y"
+
+
+def test_render_gif_rotation_filters_detected_nci_types(tmp_path):
+    from unittest.mock import patch
+
+    from xyzrender import render_gif
+
+    with patch("xyzrender.gif.render_rotation_gif") as mock_render:
+        render_gif(
+            STRUCTURES / "bimp.v000.xyz",
+            gif_rot="y",
+            detect_nci=["hb"],
+            output=tmp_path / "nci.gif",
+        )
+
+    graph = mock_render.call_args.kwargs["graph"]
+    nci_types = {data["nci_type"] for *_edge, data in graph.edges(data=True) if data.get("NCI")}
+    assert nci_types == {"hbond_bifurcated"}
+
+
+def test_render_gif_rotation_filters_molecule_without_mutating_it(tmp_path):
+    from unittest.mock import patch
+
+    from xyzrender import load, render_gif
+
+    molecule = load(STRUCTURES / "bimp.v000.xyz")
+
+    with patch("xyzrender.gif.render_rotation_gif") as mock_render:
+        render_gif(
+            molecule,
+            gif_rot="y",
+            detect_nci=["hb"],
+            output=tmp_path / "nci.gif",
+        )
+
+    graph = mock_render.call_args.kwargs["graph"]
+    nci_types = {data["nci_type"] for *_edge, data in graph.edges(data=True) if data.get("NCI")}
+    assert nci_types == {"hbond_bifurcated"}
+    assert not any(data.get("NCI") for *_edge, data in molecule.graph.edges(data=True))
+
+
+def test_render_gif_rotation_detects_ncis_after_atom_filtering(tmp_path):
+    from unittest.mock import patch
+
+    from xyzrender import render_gif
+
+    with patch("xyzrender.gif.render_rotation_gif") as mock_render:
+        render_gif(
+            STRUCTURES / "bimp.v000.xyz",
+            gif_rot="y",
+            detect_nci="pi",
+            only="1-172",
+            output=tmp_path / "nci.gif",
+        )
+
+    graph = mock_render.call_args.kwargs["graph"]
+    assert any(data.get("NCI") for *_edge, data in graph.edges(data=True))
 
 
 def test_api_render_gif_bounce(tmp_path):


### PR DESCRIPTION
Adds optional NCI type selection across static, ensemble, and animated rendering while preserving `--nci` for all detected interactions. Exact xyzgraph types and the `hb`, `pi`, and `ion` groups can be selected.

  Depends on #167.

  Closes #152.