### PR TITLE
Support trajectory frames with differing atom counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ env/
 CLAUDE*
 *plan*
 *PLAN*
+*AGENT*
 
 # VSCode config (optional)
 .vscode/

--- a/docs/source/cli_reference.md
+++ b/docs/source/cli_reference.md
@@ -199,6 +199,7 @@ Fine-grained overlay style (`atom_stroke_width`, `atom_stroke_color`, `bond_colo
 | `--gif-ts` | TS vibration GIF (via graphRC) |
 | `--gif-trj` | Trajectory / optimisation GIF (multi-frame input) |
 | `--trj-bonds` | Re-detect bonds for every frame (NEB-TS MEPs and other trajectories with changing connectivity) |
+| `--var-atoms` | Allow trajectory frames with differing atom counts (rebuilds the molecular graph for every frame) |
 | `--gif-diffuse` | Diffuse / assembly GIF — atoms scatter and reassemble |
 | `--diffuse-frames N` | Number of diffuse frames (default: 60) |
 | `--diffuse-noise FLOAT` | Per-frame random walk noise (default: 0.3) |

--- a/docs/source/examples/animations.md
+++ b/docs/source/examples/animations.md
@@ -97,6 +97,13 @@ For trajectories where connectivity changes (NEB-TS MEPs, reaction paths) add `-
 xyzrender sn2.v000.xyz --gif-trj --trj-bonds -go sn2_trj_bonds.gif
 ```
 
+Trajectories with intentionally differing atom counts are rejected by default.
+Add `--var-atoms` to accept them and rebuild the molecular graph for every frame:
+
+```bash
+xyzrender growth.xyz --gif-trj --var-atoms -go growth.gif
+```
+
 ## Diffuse / assembly
 
 ```{image} ../../../examples/images/caffeine_diffuse.gif

--- a/docs/source/python_api.md
+++ b/docs/source/python_api.md
@@ -336,6 +336,7 @@ render_gif("ts.out", gif_ts=True)                  # TS vibration GIF
 render_gif("ts.out", gif_ts=True, ts_bonds=[(1, 6)])  # skip auto-detection; use this TS bond
 render_gif("traj.xyz", gif_trj=True)               # trajectory GIF
 render_gif("mep.xyz", gif_trj=True, trj_bonds=True)  # re-detect bonds per frame
+render_gif("growth.xyz", gif_trj=True, var_atoms=True)  # allow differing atom counts
 render_gif("mol.xyz", gif_rot="y", config=cfg)     # with shared style config
 
 # Diffuse / assembly GIF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.24",
-    "xyzgraph>=1.6.13",
+    "xyzgraph>=1.6.15",
     "cclib",
     "graphrc>=1.3.7",
     "cairosvg",
@@ -27,6 +27,9 @@ classifiers = [
 
 [project.urls]
 homepage = "https://github.com/aligfellow/xyzrender"
+
+[tool.uv.sources]
+xyzgraph = { git = "https://github.com/JamesOBrien2/xyzgraph.git", rev = "63fcbd33611e73c9476d6b581bd0b387496f879d" }
 
 [project.scripts]
 xyzrender = "xyzrender.cli:main"

--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -1474,10 +1474,12 @@ def render_gif(
     opacity: float | None = None,
     # --- Orientation reference (gif_ts / gif_trj: graph after orient()) ---
     reference_graph: "nx.Graph | None" = None,
+    # --- Source trajectory frame corresponding to reference_graph ---
+    trj_reference_frame: int | None = None,
     # --- Per-frame bond detection (gif_trj only) ---
     trj_bonds: bool = False,
     # --- Allow non-uniform atom counts across frames (gif_trj only) ---
-    trj_allow_variable_atoms: bool = False,
+    var_atoms: bool = False,
     # --- NCI detection (gif_ts / gif_trj / gif_rot) ---
     detect_nci: bool = False,
     # --- Manual TS bonds (1-indexed atom numbering) ---
@@ -1542,14 +1544,20 @@ def render_gif(
         the default ``"y"`` axis.
     gif_trj:
         Trajectory animation — *molecule* must be a multi-frame XYZ with a
-        fixed atom count, unless *trj_allow_variable_atoms* is set.
+        fixed atom count, unless *var_atoms* is set.
     trj_bonds:
         Rebuild the molecular graph from every frame instead of once from
         the last frame, so changing connectivity (e.g. NEB-TS MEPs) is shown
         correctly.
-    trj_allow_variable_atoms:
+    var_atoms:
         Allow *gif_trj* frames with differing atom counts instead of
         raising an error.
+    trj_reference_frame:
+        Zero-based trajectory frame corresponding to *reference_graph*.
+        The same frame is used to derive a rotation that is applied to all
+        trajectory frames. By default this matches the frame used by
+        :func:`load`: the first frame for XYZ and the last geometry for QM
+        outputs.
     gif_bounce:
         Bounce rotation GIF. Either an amplitude in degrees (axis defaults
         to ``"y"``) or a ``(degrees, axis)`` tuple — e.g. ``50`` or
@@ -1858,9 +1866,14 @@ def render_gif(
     if gif_trj:
         from xyzrender.readers import load_trajectory_frames
 
-        frames = load_trajectory_frames(str(mol_path), allow_variable_atoms=trj_allow_variable_atoms)
+        assert mol_path is not None
+        frames = load_trajectory_frames(str(mol_path), var_atoms=var_atoms)
         if len(frames) < 2:
             raise ValueError("render_gif(gif_trj=True) requires a multi-frame XYZ file")
+
+        reference_frame = trj_reference_frame
+        if reference_frame is None:
+            reference_frame = 0 if Path(mol_path).suffix.lower() == ".xyz" else len(frames) - 1
 
         render_trajectory_gif(
             frames=frames,
@@ -1868,6 +1881,7 @@ def render_gif(
             output=str(gif_path),
             fps=gif_fps,
             reference_graph=reference_graph if reference_graph is not None else ref_graph,
+            reference_frame=reference_frame,
             axis=gif_rot,
             trj_bonds=trj_bonds,
             detect_nci=detect_nci,

--- a/src/xyzrender/api.py
+++ b/src/xyzrender/api.py
@@ -1476,6 +1476,8 @@ def render_gif(
     reference_graph: "nx.Graph | None" = None,
     # --- Per-frame bond detection (gif_trj only) ---
     trj_bonds: bool = False,
+    # --- Allow non-uniform atom counts across frames (gif_trj only) ---
+    trj_allow_variable_atoms: bool = False,
     # --- NCI detection (gif_ts / gif_trj / gif_rot) ---
     detect_nci: bool = False,
     # --- Manual TS bonds (1-indexed atom numbering) ---
@@ -1539,7 +1541,15 @@ def render_gif(
         …), or a 3-digit Miller index (``"111"``). Pass ``True`` to use
         the default ``"y"`` axis.
     gif_trj:
-        Trajectory animation — *molecule* must be a multi-frame XYZ.
+        Trajectory animation — *molecule* must be a multi-frame XYZ with a
+        fixed atom count, unless *trj_allow_variable_atoms* is set.
+    trj_bonds:
+        Rebuild the molecular graph from every frame instead of once from
+        the last frame, so changing connectivity (e.g. NEB-TS MEPs) is shown
+        correctly.
+    trj_allow_variable_atoms:
+        Allow *gif_trj* frames with differing atom counts instead of
+        raising an error.
     gif_bounce:
         Bounce rotation GIF. Either an amplitude in degrees (axis defaults
         to ``"y"``) or a ``(degrees, axis)`` tuple — e.g. ``50`` or
@@ -1848,7 +1858,7 @@ def render_gif(
     if gif_trj:
         from xyzrender.readers import load_trajectory_frames
 
-        frames = load_trajectory_frames(str(mol_path))
+        frames = load_trajectory_frames(str(mol_path), allow_variable_atoms=trj_allow_variable_atoms)
         if len(frames) < 2:
             raise ValueError("render_gif(gif_trj=True) requires a multi-frame XYZ file")
 

--- a/src/xyzrender/cli.py
+++ b/src/xyzrender/cli.py
@@ -664,7 +664,7 @@ def main() -> None:
         help="Re-detect bonds for every frame (use for NEB-TS MEPs where connectivity changes)",
     )
     gif_g.add_argument(
-        "--trj-allow-variable-atoms",
+        "--var-atoms",
         action="store_true",
         help="Allow --gif-trj frames with differing atom counts instead of rejecting them",
     )
@@ -1531,7 +1531,7 @@ def main() -> None:
                 opacity=args.opacity,
                 reference_graph=_ref_graph,
                 trj_bonds=args.trj_bonds,
-                trj_allow_variable_atoms=args.trj_allow_variable_atoms,
+                var_atoms=args.var_atoms,
                 detect_nci=args.nci_detect,
                 mo=args.mo,
                 dens=args.dens,

--- a/src/xyzrender/cli.py
+++ b/src/xyzrender/cli.py
@@ -652,11 +652,18 @@ def main() -> None:
     # --- GIF animation ---
     gif_g = p.add_argument_group("GIF animation")
     gif_g.add_argument("--gif-ts", action="store_true", help="TS vibration GIF (via graphRC)")
-    gif_g.add_argument("--gif-trj", action="store_true", help="Trajectory/optimization GIF (multi-frame input)")
+    gif_g.add_argument(
+        "--gif-trj", action="store_true", help="Trajectory/optimization GIF (multi-frame input)"
+    )
     gif_g.add_argument(
         "--trj-bonds",
         action="store_true",
         help="Re-detect bonds for every frame (use for NEB-TS MEPs where connectivity changes)",
+    )
+    gif_g.add_argument(
+        "--trj-allow-variable-atoms",
+        action="store_true",
+        help="Allow --gif-trj frames with differing atom counts instead of rejecting them",
     )
     gif_g.add_argument(
         "--gif-rot",
@@ -1521,6 +1528,7 @@ def main() -> None:
                 opacity=args.opacity,
                 reference_graph=_ref_graph,
                 trj_bonds=args.trj_bonds,
+                trj_allow_variable_atoms=args.trj_allow_variable_atoms,
                 detect_nci=args.nci_detect,
                 mo=args.mo,
                 dens=args.dens,

--- a/src/xyzrender/cli.py
+++ b/src/xyzrender/cli.py
@@ -652,9 +652,7 @@ def main() -> None:
     # --- GIF animation ---
     gif_g = p.add_argument_group("GIF animation")
     gif_g.add_argument("--gif-ts", action="store_true", help="TS vibration GIF (via graphRC)")
-    gif_g.add_argument(
-        "--gif-trj", action="store_true", help="Trajectory/optimization GIF (multi-frame input)"
-    )
+    gif_g.add_argument("--gif-trj", action="store_true", help="Trajectory/optimization GIF (multi-frame input)")
     gif_g.add_argument(
         "--trj-bonds",
         action="store_true",

--- a/src/xyzrender/gif.py
+++ b/src/xyzrender/gif.py
@@ -516,6 +516,7 @@ def render_trajectory_gif(
     multiplicity: int | None = None,
     fps: int = 10,
     reference_graph: nx.Graph | None = None,
+    reference_frame: int = 0,
     detect_nci: bool = False,
     axis: str | None = None,
     kekule: bool = False,
@@ -527,7 +528,8 @@ def render_trajectory_gif(
     to get correct bond orders, then updates positions per frame.
     If ``trj_bonds`` is True, builds a fresh graph for every frame so
     that changing connectivity (e.g. NEB-TS MEPs) is shown correctly.
-    If ``reference_graph`` is provided, all frames are rotated to match.
+    If ``reference_graph`` is provided, all frames are rotated using the
+    matching ``reference_frame`` as the un-oriented source.
     If ``detect_nci`` is True, NCI interactions are re-detected per frame
     using xyzgraph's NCIAnalyzer (topology built once, geometry per frame).
     If ``axis`` is provided, the molecule rotates 360° around that axis
@@ -535,6 +537,10 @@ def render_trajectory_gif(
     always get a fresh graph per frame, regardless of ``trj_bonds``.
     """
     from xyzgraph import build_graph
+
+    if not 0 <= reference_frame < len(frames):
+        msg = f"Trajectory reference frame {reference_frame} is out of range for {len(frames)} frames"
+        raise ValueError(msg)
 
     frame_atom_counts = {len(f["symbols"]) for f in frames}
     if len(frame_atom_counts) > 1 and not trj_bonds:
@@ -558,7 +564,8 @@ def render_trajectory_gif(
             max(bond_counts),
             bond_counts[-1],
         )
-        # Use last frame's graph as the topology anchor for Kabsch alignment.
+        reference_source_graph = frames[reference_frame]["graph"]
+        # Use last frame's graph as the topology anchor for rendering.
         graph = frames[-1]["graph"]
     else:
         # Build graph from last frame (optimized geometry → correct bond orders)
@@ -568,6 +575,18 @@ def render_trajectory_gif(
 
         if reference_graph is not None:
             _copy_ts_nci_attrs(graph, reference_graph)
+
+        source = frames[reference_frame]
+        if reference_frame == len(frames) - 1:
+            reference_source_graph = graph
+        else:
+            source_atoms = list(zip(source["symbols"], [tuple(p) for p in source["positions"]], strict=True))
+            reference_source_graph = build_graph(
+                source_atoms,
+                charge=charge,
+                multiplicity=multiplicity,
+                kekule=kekule,
+            )
 
     # NCI: build analyzer once from the fixed topology, or rebuild per frame
     # when bonds change (trj_bonds) since π-systems / sites / pair list depend
@@ -581,7 +600,7 @@ def render_trajectory_gif(
     # Apply viewer rotation if reference orientation was given
     if reference_graph is not None:
         logger.debug("Applying Kabsch rotation from viewer orientation")
-        rot = _compute_rotation(graph, reference_graph)
+        rot = _compute_rotation(reference_source_graph, reference_graph)
         frames = _rotate_frames(frames, rot)
 
     # PCA: compute once from first frame, apply consistently to all
@@ -763,6 +782,15 @@ def _rotate_vectors_in_cfg(
 def _compute_rotation(original_graph: nx.Graph, rotated_graph: nx.Graph) -> np.ndarray:
     """Compute 3x3 rotation matrix from original to rotated graph positions."""
     n = original_graph.number_of_nodes()
+    if rotated_graph.number_of_nodes() != n:
+        msg = (
+            "Trajectory reference orientation requires the reference graph and source frame to have the same atom count"
+        )
+        raise ValueError(msg)
+    original_symbols = [original_graph.nodes[i].get("symbol") for i in range(n)]
+    rotated_symbols = [rotated_graph.nodes[i].get("symbol") for i in range(n)]
+    if all(symbol is not None for symbol in original_symbols + rotated_symbols) and original_symbols != rotated_symbols:
+        raise ValueError("Trajectory reference graph and source frame must use the same atom order")
     orig = np.array([original_graph.nodes[i]["position"] for i in range(n)])
     rot = np.array([rotated_graph.nodes[i]["position"] for i in range(n)])
     return kabsch_rotation(orig, rot)

--- a/src/xyzrender/gif.py
+++ b/src/xyzrender/gif.py
@@ -531,9 +531,15 @@ def render_trajectory_gif(
     If ``detect_nci`` is True, NCI interactions are re-detected per frame
     using xyzgraph's NCIAnalyzer (topology built once, geometry per frame).
     If ``axis`` is provided, the molecule rotates 360° around that axis
-    over the course of the trajectory.
+    over the course of the trajectory. Frames with differing atom counts
+    always get a fresh graph per frame, regardless of ``trj_bonds``.
     """
     from xyzgraph import build_graph
+
+    frame_atom_counts = {len(f["symbols"]) for f in frames}
+    if len(frame_atom_counts) > 1 and not trj_bonds:
+        # A shared graph assumes a fixed atom count; force the per-frame path.
+        trj_bonds = True
 
     if trj_bonds:
         # Build one graph per frame so changing connectivity is shown correctly.
@@ -678,7 +684,8 @@ def _fixed_viewport(frames: list[dict], config: RenderConfig, rotation_axis: np.
 
     from xyzgraph import DATA
 
-    max_vdw = max(DATA.vdw.get(s, 1.5) for s in set(frames[0]["symbols"]))
+    all_symbols = {s for f in frames for s in f["symbols"]}
+    max_vdw = max(DATA.vdw.get(s, 1.5) for s in all_symbols)
     if config.vdw_indices is not None:
         atom_pad = max_vdw * config.vdw_scale
     else:

--- a/src/xyzrender/readers.py
+++ b/src/xyzrender/readers.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
-from xyzgraph import DATA, build_graph, read_xyz_file
+from xyzgraph import DATA, build_graph, read_xyz_file, read_xyz_frames
 
 from xyzrender.types import CellData
 
@@ -538,7 +538,7 @@ def detect_nci(graph: nx.Graph) -> nx.Graph:
 # ---------------------------------------------------------------------------
 
 
-def load_trajectory_frames(path: str | Path, *, allow_variable_atoms: bool = False) -> list[dict]:
+def load_trajectory_frames(path: str | Path, *, var_atoms: bool = False) -> list[dict]:
     """Load all frames from a multi-frame XYZ or QM output (cclib).
 
     Returns list of ``{"symbols": [...], "positions": [[x,y,z], ...]}``
@@ -548,7 +548,7 @@ def load_trajectory_frames(path: str | Path, *, allow_variable_atoms: bool = Fal
     ----------
     path:
         Path to a multi-frame XYZ file or QM output file.
-    allow_variable_atoms:
+    var_atoms:
         Allow frames with differing atom counts instead of raising
         ``ValueError`` (default: treat a non-uniform trajectory as malformed).
 
@@ -559,22 +559,30 @@ def load_trajectory_frames(path: str | Path, *, allow_variable_atoms: bool = Fal
     """
     p = str(path)
     logger.info("Loading trajectory from %s", p)
-    frames = _load_xyz_frames(p) if p.endswith(".xyz") else _load_qm_frames(p)
+    if p.endswith(".xyz"):
+        frames = [
+            {
+                "symbols": [symbol for symbol, _ in atoms],
+                "positions": [list(position) for _, position in atoms],
+            }
+            for atoms in read_xyz_frames(p)
+        ]
+    else:
+        frames = _load_qm_frames(p)
     logger.info("Loaded %d frames", len(frames))
 
     counts = [len(f["symbols"]) for f in frames]
     if counts and len(set(counts)) > 1:
-        if not allow_variable_atoms:
+        if not var_atoms:
             first_n = counts[0]
             bad_idx, bad_n = next((i, n) for i, n in enumerate(counts) if n != first_n)
             msg = (
-                f"Trajectory has non-uniform atom counts: first frame N={first_n}, "
-                f"frame {bad_idx} N={bad_n}. Pass allow_variable_atoms=True "
-                "(CLI: --trj-allow-variable-atoms) to explicitly allow this."
+                f"Trajectory has non-uniform atom counts: first frame has {first_n} atoms, "
+                f"frame {bad_idx} has {bad_n}. If this is intentional, use --var-atoms"
             )
             raise ValueError(msg)
         logger.info(
-            "Trajectory has non-uniform atom counts (min=%d, max=%d atoms); allow_variable_atoms=True",
+            "Trajectory has non-uniform atom counts (min=%d, max=%d atoms); var_atoms=True",
             min(counts),
             max(counts),
         )
@@ -684,62 +692,6 @@ def _parse_qm_output(path: str) -> tuple[_Atoms, int, int | None]:
         atoms.append((DATA.n2s[int(z)], (float(x), float(y), float(zc))))
 
     return atoms, getattr(data, "charge", 0), getattr(data, "mult", None)
-
-
-def _load_xyz_frames(path: str) -> list[dict]:
-    """Read all frames from a multi-frame XYZ file, each sized by its own header."""
-    with open(path) as f:
-        lines = f.read().splitlines()
-
-    frames = []
-    n_lines = len(lines)
-    i = 0
-    frame_idx = 0
-    while i < n_lines:
-        if not lines[i].strip():
-            i += 1
-            continue
-        try:
-            n_atoms = int(lines[i].strip())
-        except ValueError as e:
-            msg = f"Invalid XYZ format at line {i + 1} (frame {frame_idx}): expected atom count"
-            raise ValueError(msg) from e
-
-        atoms_start = i + 2
-        if atoms_start + n_atoms > n_lines:
-            msg = f"Frame {frame_idx} declares {n_atoms} atoms but the file ends before they are all present"
-            raise ValueError(msg)
-
-        symbols = []
-        positions = []
-        for j in range(n_atoms):
-            parts = lines[atoms_start + j].split()
-            if len(parts) < 4:
-                msg = f"Frame {frame_idx}, atom {j}: expected at least 4 columns"
-                raise ValueError(msg)
-            elem = parts[0]
-            try:
-                x, y, z = (float(v) for v in parts[1:4])
-            except ValueError as e:
-                msg = f"Frame {frame_idx}, atom {j}: invalid coordinates"
-                raise ValueError(msg) from e
-            if elem.isdigit():
-                atomic_num = int(elem)
-                if atomic_num not in DATA.n2s:
-                    msg = f"Frame {frame_idx}, atom {j}: unknown atomic number {atomic_num}"
-                    raise ValueError(msg)
-                symbol = DATA.n2s[atomic_num]
-            else:
-                symbol = elem
-            symbols.append(symbol)
-            positions.append([x, y, z])
-
-        frames.append({"symbols": symbols, "positions": positions})
-        i = atoms_start + n_atoms
-        frame_idx += 1
-
-    logger.debug("XYZ file: %d frames (atom counts: %s)", len(frames), sorted({len(f["symbols"]) for f in frames}))
-    return frames
 
 
 def _looks_like_rdkit_mol(obj) -> bool:

--- a/src/xyzrender/readers.py
+++ b/src/xyzrender/readers.py
@@ -538,7 +538,7 @@ def detect_nci(graph: nx.Graph) -> nx.Graph:
 # ---------------------------------------------------------------------------
 
 
-def load_trajectory_frames(path: str | Path) -> list[dict]:
+def load_trajectory_frames(path: str | Path, *, allow_variable_atoms: bool = False) -> list[dict]:
     """Load all frames from a multi-frame XYZ or QM output (cclib).
 
     Returns list of ``{"symbols": [...], "positions": [[x,y,z], ...]}``
@@ -548,6 +548,9 @@ def load_trajectory_frames(path: str | Path) -> list[dict]:
     ----------
     path:
         Path to a multi-frame XYZ file or QM output file.
+    allow_variable_atoms:
+        Allow frames with differing atom counts instead of raising
+        ``ValueError`` (default: treat a non-uniform trajectory as malformed).
 
     Returns
     -------
@@ -558,6 +561,23 @@ def load_trajectory_frames(path: str | Path) -> list[dict]:
     logger.info("Loading trajectory from %s", p)
     frames = _load_xyz_frames(p) if p.endswith(".xyz") else _load_qm_frames(p)
     logger.info("Loaded %d frames", len(frames))
+
+    counts = [len(f["symbols"]) for f in frames]
+    if counts and len(set(counts)) > 1:
+        if not allow_variable_atoms:
+            first_n = counts[0]
+            bad_idx, bad_n = next((i, n) for i, n in enumerate(counts) if n != first_n)
+            msg = (
+                f"Trajectory has non-uniform atom counts: first frame N={first_n}, "
+                f"frame {bad_idx} N={bad_n}. Pass allow_variable_atoms=True "
+                "(CLI: --trj-allow-variable-atoms) to explicitly allow this."
+            )
+            raise ValueError(msg)
+        logger.info(
+            "Trajectory has non-uniform atom counts (min=%d, max=%d atoms); allow_variable_atoms=True",
+            min(counts),
+            max(counts),
+        )
     return frames
 
 
@@ -667,20 +687,58 @@ def _parse_qm_output(path: str) -> tuple[_Atoms, int, int | None]:
 
 
 def _load_xyz_frames(path: str) -> list[dict]:
-    """Read all frames from a multi-frame XYZ file."""
-    from xyzgraph import count_frames_and_atoms
+    """Read all frames from a multi-frame XYZ file, each sized by its own header."""
+    with open(path) as f:
+        lines = f.read().splitlines()
 
-    n_frames, n_atoms = count_frames_and_atoms(path)
-    logger.debug("XYZ file: %d frames, %d atoms per frame", n_frames, n_atoms)
     frames = []
-    for i in range(n_frames):
-        atoms = read_xyz_file(path, frame=i)
-        frames.append(
-            {
-                "symbols": [a[0] for a in atoms],
-                "positions": [list(a[1]) for a in atoms],
-            }
-        )
+    n_lines = len(lines)
+    i = 0
+    frame_idx = 0
+    while i < n_lines:
+        if not lines[i].strip():
+            i += 1
+            continue
+        try:
+            n_atoms = int(lines[i].strip())
+        except ValueError as e:
+            msg = f"Invalid XYZ format at line {i + 1} (frame {frame_idx}): expected atom count"
+            raise ValueError(msg) from e
+
+        atoms_start = i + 2
+        if atoms_start + n_atoms > n_lines:
+            msg = f"Frame {frame_idx} declares {n_atoms} atoms but the file ends before they are all present"
+            raise ValueError(msg)
+
+        symbols = []
+        positions = []
+        for j in range(n_atoms):
+            parts = lines[atoms_start + j].split()
+            if len(parts) < 4:
+                msg = f"Frame {frame_idx}, atom {j}: expected at least 4 columns"
+                raise ValueError(msg)
+            elem = parts[0]
+            try:
+                x, y, z = (float(v) for v in parts[1:4])
+            except ValueError as e:
+                msg = f"Frame {frame_idx}, atom {j}: invalid coordinates"
+                raise ValueError(msg) from e
+            if elem.isdigit():
+                atomic_num = int(elem)
+                if atomic_num not in DATA.n2s:
+                    msg = f"Frame {frame_idx}, atom {j}: unknown atomic number {atomic_num}"
+                    raise ValueError(msg)
+                symbol = DATA.n2s[atomic_num]
+            else:
+                symbol = elem
+            symbols.append(symbol)
+            positions.append([x, y, z])
+
+        frames.append({"symbols": symbols, "positions": positions})
+        i = atoms_start + n_atoms
+        frame_idx += 1
+
+    logger.debug("XYZ file: %d frames (atom counts: %s)", len(frames), sorted({len(f["symbols"]) for f in frames}))
     return frames
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -181,6 +181,68 @@ def test_gif_ts_manual_bonds_skip_auto_ts_load(monkeypatch, tmp_path):
     assert mock_load.call_args_list[0].kwargs["ts_detect"] is False
 
 
+def test_var_atoms_is_forwarded_to_render_gif(monkeypatch, tmp_path):
+    """--var-atoms opts the public GIF API into variable frame sizes."""
+    import sys
+    from unittest.mock import patch
+
+    from xyzrender import api
+    from xyzrender.cli import main
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "xyzrender",
+            str(_CAFFEINE),
+            "--gif-trj",
+            "--var-atoms",
+            "-o",
+            str(tmp_path / "static.svg"),
+            "-go",
+            str(tmp_path / "trajectory.gif"),
+        ],
+    )
+
+    with patch.object(api, "render"), patch.object(api, "render_gif") as mock_render_gif:
+        main()
+
+    assert mock_render_gif.call_args.kwargs["var_atoms"] is True
+
+
+def test_variable_atom_trajectory_cli_recommends_var_atoms(monkeypatch, tmp_path, capsys):
+    """The CLI surfaces the exact opt-in guidance for an intentional count change."""
+    import sys
+    from unittest.mock import patch
+
+    from xyzrender import api
+    from xyzrender.cli import main
+
+    trajectory = tmp_path / "variable.xyz"
+    trajectory.write_text("2\nframe 0\nH 0 0 0\nH 0 0 0.7\n3\nframe 1\nH 0 0 0\nH 0 0 0.8\nH 0 0 1.6\n")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "xyzrender",
+            str(trajectory),
+            "--gif-trj",
+            "-o",
+            str(tmp_path / "static.svg"),
+            "-go",
+            str(tmp_path / "trajectory.gif"),
+        ],
+    )
+
+    with patch.object(api, "render"), pytest.raises(SystemExit):
+        main()
+
+    assert (
+        "Trajectory has non-uniform atom counts: first frame has 2 atoms, "
+        "frame 1 has 3. If this is intentional, use --var-atoms"
+    ) in capsys.readouterr().err
+
+
 def test_hl_too_many_args():
     """--hl with >2 arguments should error."""
     result = _run_cli(str(_CAFFEINE), "--hl", "1-5", "red", "extra", expect_error=True)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -6,6 +6,7 @@ All fixtures use checked-in example files — no rdkit or ase generation needed.
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 import numpy as np
@@ -540,19 +541,24 @@ def test_load_trajectory_frames_non_uniform_raises(tmp_path):
     p = tmp_path / "non_uniform.xyz"
     p.write_text(_NON_UNIFORM_XYZ)
 
-    with pytest.raises(ValueError, match="non-uniform atom counts"):
+    message = (
+        "Trajectory has non-uniform atom counts: first frame has 2 atoms, "
+        "frame 1 has 3. If this is intentional, use --var-atoms"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)) as exc_info:
         load_trajectory_frames(str(p))
+    assert str(exc_info.value) == message
 
 
 def test_load_trajectory_frames_non_uniform_allowed_with_flag(tmp_path):
-    """allow_variable_atoms=True opts into loading a non-uniform trajectory
+    """var_atoms=True opts into loading a non-uniform trajectory
     instead of raising."""
     from xyzrender.readers import load_trajectory_frames
 
     p = tmp_path / "non_uniform.xyz"
     p.write_text(_NON_UNIFORM_XYZ)
 
-    frames = load_trajectory_frames(str(p), allow_variable_atoms=True)
+    frames = load_trajectory_frames(str(p), var_atoms=True)
     assert [len(f["symbols"]) for f in frames] == [2, 3]
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -497,6 +497,65 @@ def test_trajectory_diagnostic_warns_on_single_frame(caplog, monkeypatch):
     assert any("may not contain the expected multistep data" in m for m in msgs)
 
 
+_UNIFORM_XYZ = """2
+frame 0
+H 0.0 0.0 0.0
+H 0.0 0.0 0.74
+2
+frame 1
+H 0.0 0.0 0.0
+H 0.0 0.0 0.80
+"""
+
+_NON_UNIFORM_XYZ = """2
+frame 0
+H 0.0 0.0 0.0
+H 0.0 0.0 0.74
+3
+frame 1
+H 0.0 0.0 0.0
+H 0.0 0.0 0.80
+H 0.0 0.0 1.60
+"""
+
+
+def test_load_trajectory_frames_uniform_atom_counts(tmp_path):
+    """A fixed-atom-count trajectory loads normally with no error."""
+    from xyzrender.readers import load_trajectory_frames
+
+    p = tmp_path / "uniform.xyz"
+    p.write_text(_UNIFORM_XYZ)
+
+    frames = load_trajectory_frames(str(p))
+    assert len(frames) == 2
+    assert [len(f["symbols"]) for f in frames] == [2, 2]
+    assert frames[1]["positions"][1] == [0.0, 0.0, 0.80]
+
+
+def test_load_trajectory_frames_non_uniform_raises(tmp_path):
+    """A trajectory whose frames have differing atom counts is rejected by
+    default with a clear, early ValueError."""
+    from xyzrender.readers import load_trajectory_frames
+
+    p = tmp_path / "non_uniform.xyz"
+    p.write_text(_NON_UNIFORM_XYZ)
+
+    with pytest.raises(ValueError, match="non-uniform atom counts"):
+        load_trajectory_frames(str(p))
+
+
+def test_load_trajectory_frames_non_uniform_allowed_with_flag(tmp_path):
+    """allow_variable_atoms=True opts into loading a non-uniform trajectory
+    instead of raising."""
+    from xyzrender.readers import load_trajectory_frames
+
+    p = tmp_path / "non_uniform.xyz"
+    p.write_text(_NON_UNIFORM_XYZ)
+
+    frames = load_trajectory_frames(str(p), allow_variable_atoms=True)
+    assert [len(f["symbols"]) for f in frames] == [2, 3]
+
+
 class TestQeSniff:
     """Test QE vs Q-Chem disambiguation for .in files."""
 

--- a/tests/test_gif.py
+++ b/tests/test_gif.py
@@ -210,8 +210,48 @@ def test_render_trajectory_gif_trj_bonds(tmp_path):
     bond_counts = [f["graph"].number_of_edges() for f in seen]
     # sn2.v000.xyz: bond forms across the SN2 reaction so counts must vary
     assert len(set(bond_counts)) > 1, f"expected varying per-frame bond counts, got {bond_counts}"
-    # The graphs must be distinct objects (not all aliased to the last-frame graph)
-    assert len({id(f["graph"]) for f in seen}) == len(seen)
+
+
+# ---------------------------------------------------------------------------
+# Non-uniform atom counts across frames (issue #169)
+# ---------------------------------------------------------------------------
+
+_VARIABLE_ATOM_FRAMES = [
+    {"symbols": ["H", "H"], "positions": [[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]]},
+    {
+        "symbols": ["H", "H", "H"],
+        "positions": [[0.0, 0.0, 0.0], [0.0, 0.0, 0.80], [0.0, 0.0, 1.60]],
+    },
+]
+
+
+def test_render_trajectory_gif_auto_enables_trj_bonds_for_variable_atoms(tmp_path):
+    """Differing atom counts must trigger per-frame graphs even if trj_bonds=False."""
+    from unittest.mock import patch
+
+    from xyzrender.gif import render_trajectory_gif
+    from xyzrender.types import RenderConfig
+
+    captured: dict = {}
+
+    def _spy(graph, frames, config, **_):
+        captured["frames"] = frames
+        return [b""] * len(frames)
+
+    with (
+        patch("xyzrender.gif._render_frames", side_effect=_spy),
+        patch("xyzrender.gif._stitch_gif"),
+    ):
+        render_trajectory_gif(
+            frames=[dict(f) for f in _VARIABLE_ATOM_FRAMES],
+            config=RenderConfig(),
+            output=str(tmp_path / "x.gif"),
+            trj_bonds=False,
+        )
+
+    seen = captured["frames"]
+    assert all("graph" in f for f in seen), "variable atom counts must trigger per-frame graphs"
+    assert [g.number_of_nodes() for g in (f["graph"] for f in seen)] == [2, 3]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gif.py
+++ b/tests/test_gif.py
@@ -1,5 +1,6 @@
 """Tests for gif.py — rotation axis parsing and GIF rendering."""
 
+import re
 from pathlib import Path
 
 import numpy as np
@@ -224,6 +225,71 @@ _VARIABLE_ATOM_FRAMES = [
     },
 ]
 
+_VARIABLE_ATOM_XYZ = """2
+frame 0: H2
+H  0.000  0.000  0.000
+H  0.000  0.000  0.740
+3
+frame 1: H3
+H  0.000  0.000  0.000
+H  0.000  0.000  0.800
+H  0.000  0.000  1.600
+2
+frame 2: H2
+H  1.000  0.000  0.000
+H  1.000  0.000  0.750
+2
+frame 3: H2
+H  0.000  1.000  0.000
+H  0.000  1.000  0.730
+"""
+
+
+def test_render_gif_variable_atoms_recommends_opt_in(tmp_path):
+    """The public trajectory pipeline explains how to allow intentional count changes."""
+    from xyzrender import render_gif
+
+    trajectory = tmp_path / "variable.xyz"
+    trajectory.write_text(_VARIABLE_ATOM_XYZ)
+
+    message = (
+        "Trajectory has non-uniform atom counts: first frame has 2 atoms, "
+        "frame 1 has 3. If this is intentional, use --var-atoms"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)) as exc_info:
+        render_gif(trajectory, gif_trj=True, output=tmp_path / "variable.gif")
+    assert str(exc_info.value) == message
+
+
+def test_render_gif_variable_atoms_opt_in_reaches_public_renderer(tmp_path):
+    """var_atoms=True renders every independently sized frame through the public API."""
+    from unittest.mock import patch
+
+    from xyzrender import render_gif
+
+    trajectory = tmp_path / "variable.xyz"
+    trajectory.write_text(_VARIABLE_ATOM_XYZ)
+    captured: dict = {}
+
+    def _spy(graph, frames, config, **_):
+        captured["frames"] = frames
+        return [b""] * len(frames)
+
+    with (
+        patch("xyzrender.gif._render_frames", side_effect=_spy),
+        patch("xyzrender.gif._stitch_gif"),
+    ):
+        render_gif(
+            trajectory,
+            gif_trj=True,
+            var_atoms=True,
+            orient=False,
+            output=tmp_path / "variable.gif",
+        )
+
+    assert [len(frame["symbols"]) for frame in captured["frames"]] == [2, 3, 2, 2]
+    assert all("graph" in frame for frame in captured["frames"])
+
 
 def test_render_trajectory_gif_auto_enables_trj_bonds_for_variable_atoms(tmp_path):
     """Differing atom counts must trigger per-frame graphs even if trj_bonds=False."""
@@ -252,6 +318,76 @@ def test_render_trajectory_gif_auto_enables_trj_bonds_for_variable_atoms(tmp_pat
     seen = captured["frames"]
     assert all("graph" in f for f in seen), "variable atom counts must trigger per-frame graphs"
     assert [g.number_of_nodes() for g in (f["graph"] for f in seen)] == [2, 3]
+
+
+def test_render_trajectory_gif_orients_from_matching_reference_frame(tmp_path):
+    """Reference orientation must not align a differently sized final frame."""
+    from unittest.mock import patch
+
+    import networkx as nx
+
+    from xyzrender.gif import render_trajectory_gif
+    from xyzrender.types import RenderConfig
+
+    frames = [
+        {
+            "symbols": ["C", "N", "O"],
+            "positions": [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        },
+        {
+            "symbols": ["C", "N", "O", "H"],
+            "positions": [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 1.0]],
+        },
+    ]
+    reference = nx.Graph()
+    for i, (symbol, position) in enumerate(
+        zip(frames[0]["symbols"], [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]], strict=True)
+    ):
+        reference.add_node(i, symbol=symbol, position=position)
+
+    captured: dict = {}
+
+    def _spy(graph, rendered_frames, config, **_):
+        captured["frames"] = rendered_frames
+        return [b""] * len(rendered_frames)
+
+    with (
+        patch("xyzrender.gif._render_frames", side_effect=_spy),
+        patch("xyzrender.gif._stitch_gif"),
+    ):
+        render_trajectory_gif(
+            frames=frames,
+            config=RenderConfig(auto_orient=False),
+            output=str(tmp_path / "oriented.gif"),
+            reference_graph=reference,
+        )
+
+    assert [len(frame["positions"]) for frame in captured["frames"]] == [3, 4]
+    np.testing.assert_allclose(
+        captured["frames"][0]["positions"],
+        [[2 / 3, 0.0, 0.0], [2 / 3, 1.0, 0.0], [-1 / 3, 0.0, 0.0]],
+        atol=1e-12,
+    )
+
+    with pytest.raises(ValueError, match="reference graph and source frame to have the same atom count"):
+        render_trajectory_gif(
+            frames=frames,
+            config=RenderConfig(auto_orient=False),
+            output=str(tmp_path / "wrong-reference.gif"),
+            reference_graph=reference,
+            reference_frame=1,
+        )
+
+    mismatched_reference = reference.copy()
+    mismatched_reference.nodes[1]["symbol"] = "O"
+    mismatched_reference.nodes[2]["symbol"] = "N"
+    with pytest.raises(ValueError, match="same atom order"):
+        render_trajectory_gif(
+            frames=frames,
+            config=RenderConfig(auto_orient=False),
+            output=str(tmp_path / "wrong-order.gif"),
+            reference_graph=mismatched_reference,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2192,8 +2192,8 @@ wheels = [
 
 [[package]]
 name = "xyzgraph"
-version = "1.6.14"
-source = { registry = "https://pypi.org/simple" }
+version = "1.6.15"
+source = { git = "https://github.com/JamesOBrien2/xyzgraph.git?rev=63fcbd33611e73c9476d6b581bd0b387496f879d#63fcbd33611e73c9476d6b581bd0b387496f879d" }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2201,14 +2201,10 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "rdkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/90/93e5da04ef7efed8d8737aff24171886dd2738060295cd3b881b3a0d6919/xyzgraph-1.6.14.tar.gz", hash = "sha256:360cbee22172c0823dbc2c43ca109a3a1212bd7bdb029fd8998da676b3fe99a3", size = 181173, upload-time = "2026-07-20T14:48:22.813Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/e7/35f138e79a0ba3fae37f23af80a55cbdf3a616b635799579bb3fd87e29d2/xyzgraph-1.6.14-py3-none-any.whl", hash = "sha256:1aecb1c07f4b32364cd21e1d52e2f657a93b15504225c2cddb672d24b783aea7", size = 131082, upload-time = "2026-07-20T14:48:20.53Z" },
-]
 
 [[package]]
 name = "xyzrender"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "cairosvg" },
@@ -2275,7 +2271,7 @@ requires-dist = [
     { name = "shelxfile", marker = "extra == 'shelxl'" },
     { name = "vmol", marker = "extra == 'all'", specifier = ">=3.0rc7" },
     { name = "vmol", marker = "extra == 'v'", specifier = ">=3.0rc7" },
-    { name = "xyzgraph", specifier = ">=1.6.13" },
+    { name = "xyzgraph", git = "https://github.com/JamesOBrien2/xyzgraph.git?rev=63fcbd33611e73c9476d6b581bd0b387496f879d" },
 ]
 provides-extras = ["smi", "cif", "shelxl", "v", "all"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -272,7 +272,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -550,7 +550,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -700,17 +700,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -725,18 +725,18 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -748,7 +748,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1818,7 +1818,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1877,7 +1877,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -1963,7 +1963,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/92/514f86ff5c08984c4eb1b119a80c99cc3e3478b5d4682676e0b944d7ba9a/shelxfile-24-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:a42a79829d5e052c1dfc0256f1cad9f15fe8c4e1e4ea5ba1991ccdc40f00321d", size = 256246, upload-time = "2026-06-04T13:44:28.709Z" },
@@ -2192,7 +2192,7 @@ wheels = [
 
 [[package]]
 name = "xyzgraph"
-version = "1.6.13"
+version = "1.6.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2201,14 +2201,14 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "rdkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/52/0a724654181fbe2492081acc05ece6ec96041a6b613cc282c49150d497ff/xyzgraph-1.6.13.tar.gz", hash = "sha256:54bdc8dfd2eaf8dd56a8663e1e5280238328cb46eb181f6796a864c8de0d728f", size = 180418, upload-time = "2026-07-11T16:03:11.024Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/90/93e5da04ef7efed8d8737aff24171886dd2738060295cd3b881b3a0d6919/xyzgraph-1.6.14.tar.gz", hash = "sha256:360cbee22172c0823dbc2c43ca109a3a1212bd7bdb029fd8998da676b3fe99a3", size = 181173, upload-time = "2026-07-20T14:48:22.813Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/80/9a966abdb505c5042e14136d4fc6a0ce0a3896d77ca02ab87b288e5417db/xyzgraph-1.6.13-py3-none-any.whl", hash = "sha256:8442d6d71bfc2f85944e1e5dc015e82f4abe988062b8db8e99ec9ef534b71df9", size = 130242, upload-time = "2026-07-11T16:03:09.042Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e7/35f138e79a0ba3fae37f23af80a55cbdf3a616b635799579bb3fd87e29d2/xyzgraph-1.6.14-py3-none-any.whl", hash = "sha256:1aecb1c07f4b32364cd21e1d52e2f657a93b15504225c2cddb672d24b783aea7", size = 131082, upload-time = "2026-07-20T14:48:20.53Z" },
 ]
 
 [[package]]
 name = "xyzrender"
-version = "0.3.5"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "cairosvg" },


### PR DESCRIPTION
Fixes #169

Uses the canonical variable-frame parser from aligfellow/xyzgraph#62. Adds the opt-in `--var-atoms` / `var_atoms=True` path, rebuilds each frame's graph independently, and derives orientation from a matching trajectory frame.

Depends on aligfellow/xyzgraph#62. The branch temporarily resolves xyzgraph from that PR's commit; switch back to the published `xyzgraph>=1.6.15` release before merge.